### PR TITLE
Make weights public

### DIFF
--- a/models.go
+++ b/models.go
@@ -4,30 +4,6 @@ import (
 	"time"
 )
 
-type weights [13]float64
-
-func defaultWeights() weights {
-	return weights{1, 1, 5, -0.5, -0.5, 0.2, 1.4, -0.12, 0.8, 2, -0.2, 0.2, 1}
-}
-
-type Parameters struct {
-	RequestRetention float64
-	MaximumInterval  float64
-	EasyBonus        float64
-	HardFactor       float64
-	W                weights
-}
-
-func DefaultParam() Parameters {
-	return Parameters{
-		RequestRetention: 0.9,
-		MaximumInterval:  36500,
-		EasyBonus:        1.3,
-		HardFactor:       1.2,
-		W:                defaultWeights(),
-	}
-}
-
 type Card struct {
 	Due           time.Time `json:"Due"`
 	Stability     float64   `json:"Stability"`

--- a/params.go
+++ b/params.go
@@ -3,11 +3,11 @@ package fsrs
 type Weights [13]float64
 
 type Parameters struct {
-	RequestRetention float64
-	MaximumInterval  float64
-	EasyBonus        float64
-	HardFactor       float64
-	W                Weights
+	RequestRetention float64 `json:"RequestRetention"`
+	MaximumInterval  float64 `json:"MaximumInterval"`
+	EasyBonus        float64 `json:"EasyBonus"`
+	HardFactor       float64 `json:"HardFactor"`
+	W                Weights `json:"Weights"`
 }
 
 func DefaultParam() Parameters {

--- a/params.go
+++ b/params.go
@@ -1,0 +1,25 @@
+package fsrs
+
+type Weights [13]float64
+
+type Parameters struct {
+	RequestRetention float64
+	MaximumInterval  float64
+	EasyBonus        float64
+	HardFactor       float64
+	W                Weights
+}
+
+func DefaultParam() Parameters {
+	return Parameters{
+		RequestRetention: 0.9,
+		MaximumInterval:  36500,
+		EasyBonus:        1.3,
+		HardFactor:       1.2,
+		W:                DefaultWeights(),
+	}
+}
+
+func DefaultWeights() Weights {
+	return Weights{1, 1, 5, -0.5, -0.5, 0.2, 1.4, -0.12, 0.8, 2, -0.2, 0.2, 1}
+}


### PR DESCRIPTION
If we implement the optimizer in the future (which already exists in a Jupyter Notebook), we need to save and restore the parameters (including weights).

The `weights` are currently non-public. The PR makes this public by renaming it to `Weights`. Since the original one is non-public, this won't introduce breaking change.