### PR TITLE
chore(ci/docs): align module path, docs, and CI with v4 and Go 1.26

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,15 +6,17 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        go: [ 1.21.x, 1.22.x ]
+        go: [ 1.26.x ]
     env:
       OS: ${{ matrix.os }}
       GO: ${{ matrix.go }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go }}
+      - name: Run go vet
+        run: go vet ./...
       - name: Run tests
         run: go test -race -coverprofile coverage.txt -covermode atomic ./...

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # go-fsrs
 
-[![Go Reference](https://pkg.go.dev/badge/github.com/open-spaced-repetition/go-fsrs/v3.svg)](https://pkg.go.dev/github.com/open-spaced-repetition/go-fsrs/v3) [![Go Report Card](https://goreportcard.com/badge/github.com/open-spaced-repetition/go-fsrs/v3)](https://goreportcard.com/report/github.com/open-spaced-repetition/go-fsrs/v3)
+[![Go Reference](https://pkg.go.dev/badge/github.com/open-spaced-repetition/go-fsrs/v4.svg)](https://pkg.go.dev/github.com/open-spaced-repetition/go-fsrs/v4) [![Go Report Card](https://goreportcard.com/badge/github.com/open-spaced-repetition/go-fsrs/v4)](https://goreportcard.com/report/github.com/open-spaced-repetition/go-fsrs/v4)
 ![Go version](https://img.shields.io/github/go-mod/go-version/open-spaced-repetition/go-fsrs)
 
 Go module implements [Free Spaced Repetition Scheduler algorithm](https://github.com/open-spaced-repetition/free-spaced-repetition-scheduler)
@@ -8,12 +8,12 @@ Go module implements [Free Spaced Repetition Scheduler algorithm](https://github
 ## Install
 
 ```bash
-go get -u github.com/open-spaced-repetition/go-fsrs/v3@latest
+go get -u github.com/open-spaced-repetition/go-fsrs/v4@latest
 ```
 
 ## Usage
 
-Please see [GoDoc](https://pkg.go.dev/github.com/open-spaced-repetition/go-fsrs/v3)
+Please see [GoDoc](https://pkg.go.dev/github.com/open-spaced-repetition/go-fsrs/v4)
 and [Wiki](https://github.com/open-spaced-repetition/go-fsrs/wiki) for documents.
 
 ## Contributing

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/open-spaced-repetition/go-fsrs/v3
+module github.com/open-spaced-repetition/go-fsrs/v4
 
-go 1.21
+go 1.26


### PR DESCRIPTION
## Summary
This PR establishes the baseline migration to module `v4` and Go `1.26`, and aligns CI + README references accordingly.

## Context
The FSRS v6 implementation will be delivered in follow-up PRs.
Before that, we need a clean foundation where:
- module path is already `v4`
- CI is already running on Go `1.26`
- public install/docs references are already consistent with `v4`

## What Changed

### 1) Module and toolchain baseline
- Updated module path:
  - `github.com/open-spaced-repetition/go-fsrs/v3` -> `github.com/open-spaced-repetition/go-fsrs/v4`
- Updated Go directive:
  - `go 1.21` -> `go 1.26`

### 2) CI alignment
- Updated workflow Go matrix to `1.26.x`
- Upgraded GitHub Actions:
  - `actions/checkout@v2` -> `actions/checkout@v4`
  - `actions/setup-go@v2` -> `actions/setup-go@v5`
- Added explicit `go vet ./...` step before tests

### 3) Documentation and developer entry points
- Updated README references from `v3` to `v4`:
  - Go Reference badge
  - Go Report Card badge
  - `go get` install command
  - GoDoc link

## Why This PR Is Separate
This PR is intentionally scoped to versioning/CI/docs only, so reviewers can validate migration infra independently from algorithmic changes.

## Breaking Changes
- Import path for consumers changes from:
  - `github.com/open-spaced-repetition/go-fsrs/v3`
  to
  - `github.com/open-spaced-repetition/go-fsrs/v4`
- Minimum Go version for this module is now `1.26`.

## Validation
- [x] `go test ./...`
- [x] Workflow updated to run vet + tests on Go 1.26

## Out of Scope (Follow-up PRs)
- FSRS v6 core engine updates (weights/formulas/scheduler internals)
- Test expectation refresh for FSRS v6 behavior
- Migration utility helpers (SM-2 reverse mapping / v4.5 weight conversion)