### PR TITLE
feat(fsrs): export ForgettingCurve as public API

### DIFF
--- a/fsrs.go
+++ b/fsrs.go
@@ -34,5 +34,5 @@ func (f *FSRS) GetRetrievability(card Card, now time.Time) float64 {
 		return 0
 	}
 	elapsedDays := math.Max(0, dateDiffRaw(card.LastReview, now))
-	return f.Parameters.forgettingCurve(elapsedDays, card.Stability)
+	return f.Parameters.ForgettingCurve(elapsedDays, card.Stability)
 }

--- a/fsrs_test.go
+++ b/fsrs_test.go
@@ -397,13 +397,13 @@ func TestDecayAndFactorDerivedFromW20(t *testing.T) {
 	p.Decay = -0.5
 	p.Factor = math.Pow(0.9, 1.0/p.Decay) - 1.0
 
-	got := p.forgettingCurve(1, 1)
+	got := p.ForgettingCurve(1, 1)
 	wantDecay := -p.W[20]
 	wantFactor := math.Pow(0.9, 1.0/wantDecay) - 1.0
 	want := math.Pow(1+wantFactor, wantDecay)
 
 	if math.Abs(got-want) > 1e-12 {
-		t.Fatalf("forgettingCurve should use W[20], got=%v want=%v", got, want)
+		t.Fatalf("ForgettingCurve should use W[20], got=%v want=%v", got, want)
 	}
 }
 
@@ -526,7 +526,7 @@ func BenchmarkNextState(b *testing.B) {
 func BenchmarkCurrentRetrievability(b *testing.B) {
 	p := DefaultParam()
 	for b.Loop() {
-		p.forgettingCurve(21, 51.344814)
+		p.ForgettingCurve(21, 51.344814)
 	}
 }
 

--- a/parameters.go
+++ b/parameters.go
@@ -97,7 +97,7 @@ func (p *Parameters) decayAndFactor() (float64, float64) {
 	return decay, factor
 }
 
-func (p *Parameters) forgettingCurve(elapsedDays float64, stability float64) float64 {
+func (p *Parameters) ForgettingCurve(elapsedDays float64, stability float64) float64 {
 	decay, factor := p.decayAndFactor()
 	stability = constrainStability(stability)
 	return math.Pow(1+factor*elapsedDays/stability, decay)
@@ -180,7 +180,7 @@ func (p *Parameters) nextStateInner(current *MemoryState, desiredRetention, elap
 		if elapsed == 0 && p.EnableShortTerm {
 			newS = p.shortTermStability(current.Stability, grade)
 		} else {
-			retrievability := p.forgettingCurve(elapsed, current.Stability)
+			retrievability := p.ForgettingCurve(elapsed, current.Stability)
 			if grade == Again {
 				newS = p.nextForgetStability(current.Difficulty, current.Stability, retrievability)
 			} else {

--- a/scheduler_basic.go
+++ b/scheduler_basic.go
@@ -113,7 +113,7 @@ func (bs basicScheduler) learningState(grade Rating) SchedulingInfo {
 
 	var retrievability float64
 	if interval > 0 {
-		retrievability = bs.parameters.forgettingCurve(interval, bs.last.Stability)
+		retrievability = bs.parameters.ForgettingCurve(interval, bs.last.Stability)
 	}
 	next.Stability = bs.computeLearningStability(grade, interval, retrievability)
 
@@ -190,7 +190,7 @@ func (bs basicScheduler) reviewState(grade Rating) SchedulingInfo {
 		nextEasy.Difficulty = bs.parameters.nextDifficulty(difficulty, Easy)
 		nextEasy.Stability = bs.parameters.shortTermStability(stability, Easy)
 	} else {
-		retrievability := bs.parameters.forgettingCurve(interval, stability)
+		retrievability := bs.parameters.ForgettingCurve(interval, stability)
 		bs.nextDs(&nextAgain, &nextHard, &nextGood, &nextEasy, difficulty, stability, retrievability)
 	}
 

--- a/scheduler_longterm.go
+++ b/scheduler_longterm.go
@@ -66,7 +66,7 @@ func (lts longTermScheduler) reviewState(grade Rating) SchedulingInfo {
 	interval := float64(lts.current.ElapsedDays)
 	difficulty := lts.last.Difficulty
 	stability := lts.last.Stability
-	retrievability := lts.parameters.forgettingCurve(interval, stability)
+	retrievability := lts.parameters.ForgettingCurve(interval, stability)
 
 	nextAgain := lts.current
 	nextHard := lts.current


### PR DESCRIPTION
## Summary

Export the internal `forgettingCurve` method as public `ForgettingCurve` on `Parameters`, allowing consumers to compute retrievability directly from pre-calculated elapsed days and stability values without constructing a `Card` + `time.Time`.

## Changes Made

- Rename `forgettingCurve` → `ForgettingCurve` on `Parameters` (parameters.go)
- Update all 9 internal references across 5 files
- Accessible as `fsrs.ForgettingCurve(elapsedDays, stability)` via `FSRS` embedding

## Breaking Changes

None — `GetRetrievability(card, now)` continues to work unchanged.

Closes #44