### PR TITLE
feat(errors): introduce structured Error type for programmatic error classification

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -1,21 +1,72 @@
 package fsrs
 
-import "errors"
+// ErrorCode identifies a specific error condition returned by FSRS operations.
+type ErrorCode int
+
+const (
+	ErrCodeInvalidParameters ErrorCode = iota
+	ErrCodeInvalidInput
+	ErrCodeManualRating
+	ErrCodeInvalidRating
+	ErrCodeManualStateRequired
+	ErrCodeManualDueRequired
+)
+
+// Error represents a structured FSRS error with a machine-readable code
+// and a human-readable message.
+type Error struct {
+	Code    ErrorCode
+	Message string
+}
+
+// Error returns the human-readable error message. Implements the error interface.
+func (e *Error) Error() string {
+	if e == nil {
+		return "fsrs: <nil>"
+	}
+	return e.Message
+}
+
+// Is reports whether this error matches the target by comparing ErrorCode values.
+// Returns true when both are nil. Returns false when only one is nil or the
+// target is not an *Error.
+func (e *Error) Is(target error) bool {
+	if e == nil {
+		return target == nil
+	}
+	t, ok := target.(*Error)
+	if !ok || t == nil {
+		return false
+	}
+	return e.Code == t.Code
+}
 
 var (
 	// ErrManualRating is returned by Rollback when the review log entry represents
 	// a manual (non-graded) operation that cannot be rolled back.
-	ErrManualRating = errors.New("fsrs: cannot rollback a manual rating")
+	ErrManualRating = &Error{
+		Code:    ErrCodeManualRating,
+		Message: "fsrs: cannot rollback a manual rating",
+	}
 
 	// ErrInvalidRating is returned by Rollback when the review log rating is
 	// outside the valid range [Again, Easy].
-	ErrInvalidRating = errors.New("fsrs: invalid rating for rollback")
+	ErrInvalidRating = &Error{
+		Code:    ErrCodeInvalidRating,
+		Message: "fsrs: invalid rating for rollback",
+	}
 
 	// ErrManualStateRequired is returned by Reschedule when a manual review entry
 	// is missing the required State field.
-	ErrManualStateRequired = errors.New("fsrs: state is required for manual rating")
+	ErrManualStateRequired = &Error{
+		Code:    ErrCodeManualStateRequired,
+		Message: "fsrs: state is required for manual rating",
+	}
 
 	// ErrManualDueRequired is returned by Reschedule when a manual review entry
 	// with a non-New state is missing the required Due field.
-	ErrManualDueRequired = errors.New("fsrs: due is required for manual rating when state is not New")
+	ErrManualDueRequired = &Error{
+		Code:    ErrCodeManualDueRequired,
+		Message: "fsrs: due is required for manual rating when state is not New",
+	}
 )

--- a/fsrs_test.go
+++ b/fsrs_test.go
@@ -3137,6 +3137,109 @@ func TestApplyFuzz(t *testing.T) {
 	})
 }
 
+func TestErrorType(t *testing.T) {
+	t.Run("Error() returns message", func(t *testing.T) {
+		err := &Error{Code: ErrCodeInvalidInput, Message: "test message"}
+		if err.Error() != "test message" {
+			t.Errorf("expected 'test message', got=%v", err.Error())
+		}
+	})
+
+	t.Run("errors.Is matches by code", func(t *testing.T) {
+		err := &Error{Code: ErrCodeManualRating, Message: "different instance"}
+		if !errors.Is(err, ErrManualRating) {
+			t.Error("expected errors.Is to match by code")
+		}
+	})
+
+	t.Run("errors.Is does not match different code", func(t *testing.T) {
+		err := &Error{Code: ErrCodeInvalidRating, Message: "different code"}
+		if errors.Is(err, ErrManualRating) {
+			t.Error("expected errors.Is NOT to match different code")
+		}
+	})
+
+	t.Run("errors.Is works with singleton vars", func(t *testing.T) {
+		if !errors.Is(ErrManualRating, ErrManualRating) {
+			t.Error("expected singleton to match itself")
+		}
+		if !errors.Is(ErrInvalidRating, ErrInvalidRating) {
+			t.Error("expected singleton to match itself")
+		}
+		if errors.Is(ErrManualRating, ErrInvalidRating) {
+			t.Error("expected different singletons NOT to match")
+		}
+	})
+
+	t.Run("errors.As extracts code", func(t *testing.T) {
+		err := &Error{Code: ErrCodeManualStateRequired, Message: "state needed"}
+		var fsrsErr *Error
+		if !errors.As(err, &fsrsErr) {
+			t.Fatal("expected errors.As to extract *Error")
+		}
+		if fsrsErr.Code != ErrCodeManualStateRequired {
+			t.Errorf("expected code %v, got=%v", ErrCodeManualStateRequired, fsrsErr.Code)
+		}
+	})
+
+	t.Run("existing error messages unchanged", func(t *testing.T) {
+		if ErrManualRating.Error() != "fsrs: cannot rollback a manual rating" {
+			t.Errorf("ErrManualRating message changed: %v", ErrManualRating.Error())
+		}
+		if ErrInvalidRating.Error() != "fsrs: invalid rating for rollback" {
+			t.Errorf("ErrInvalidRating message changed: %v", ErrInvalidRating.Error())
+		}
+		if ErrManualStateRequired.Error() != "fsrs: state is required for manual rating" {
+			t.Errorf("ErrManualStateRequired message changed: %v", ErrManualStateRequired.Error())
+		}
+		if ErrManualDueRequired.Error() != "fsrs: due is required for manual rating when state is not New" {
+			t.Errorf("ErrManualDueRequired message changed: %v", ErrManualDueRequired.Error())
+		}
+	})
+
+	t.Run("errors.Is returns false for non-*Error target", func(t *testing.T) {
+		if errors.Is(ErrManualRating, errors.New("fsrs: cannot rollback a manual rating")) {
+			t.Error("expected errors.Is to return false for plain error")
+		}
+	})
+
+	t.Run("Is handles nil safely", func(t *testing.T) {
+		var nilErr *Error
+		if errors.Is(ErrManualRating, nilErr) {
+			t.Error("expected errors.Is with nil target to return false")
+		}
+		if nilErr.Is(ErrManualRating) {
+			t.Error("expected nil receiver.Is to return false")
+		}
+		if nilErr.Error() != "fsrs: <nil>" {
+			t.Errorf("expected nil Error() to return 'fsrs: <nil>', got=%v", nilErr.Error())
+		}
+	})
+
+	t.Run("errors.As negative case", func(t *testing.T) {
+		plainErr := errors.New("plain error")
+		var fsrsErr *Error
+		if errors.As(plainErr, &fsrsErr) {
+			t.Error("expected errors.As to fail for non-*Error")
+		}
+	})
+
+	t.Run("sentinel codes match constants", func(t *testing.T) {
+		if ErrManualRating.Code != ErrCodeManualRating {
+			t.Errorf("ErrManualRating.Code=%v, want ErrCodeManualRating=%v", ErrManualRating.Code, ErrCodeManualRating)
+		}
+		if ErrInvalidRating.Code != ErrCodeInvalidRating {
+			t.Errorf("ErrInvalidRating.Code=%v, want ErrCodeInvalidRating=%v", ErrInvalidRating.Code, ErrCodeInvalidRating)
+		}
+		if ErrManualStateRequired.Code != ErrCodeManualStateRequired {
+			t.Errorf("ErrManualStateRequired.Code=%v, want ErrCodeManualStateRequired=%v", ErrManualStateRequired.Code, ErrCodeManualStateRequired)
+		}
+		if ErrManualDueRequired.Code != ErrCodeManualDueRequired {
+			t.Errorf("ErrManualDueRequired.Code=%v, want ErrCodeManualDueRequired=%v", ErrManualDueRequired.Code, ErrCodeManualDueRequired)
+		}
+	})
+}
+
 func TestGetFuzzRange(t *testing.T) {
 	t.Run("small interval uses minimal delta", func(t *testing.T) {
 		minIvl, maxIvl := getFuzzRange(3, 0, 36500)


### PR DESCRIPTION
## Summary

Introduce a structured `Error` type with machine-readable error codes to replace string-based errors, enabling programmatic error classification via `errors.Is()`/`errors.As()` while preserving backward compatibility.

## Motivation

The library previously used plain string errors (`errors.New()`) which only allowed message-based comparison, limiting programmatic error handling. The new structured Error type (inspired by fsrs-rs `FSRSError` enum) provides explicit error codes while maintaining Go's error interface compatibility.

## Changes Made

- Added `ErrorCode` int enum with 6 codes (4 active: ManualRating, InvalidRating, ManualStateRequired, ManualDueRequired; 2 reserved for #58: InvalidParameters, InvalidInput)
- Implemented `Error` struct with `Code` and `Message` fields, nil-safe `Error()` and `Is()` methods
- Migrated 4 sentinel errors from `errors.New()` to `&Error{}` singletons with preserved messages and doc comments
- Added `TestErrorType` with 10 subtests covering Error(), errors.Is, errors.As, nil safety, sentinel code verification, and backward compatibility

## Testing

- [x] Tested locally
- [x] Unit tests added (10 subtests)
- [x] No regressions — all existing tests pass

## Breaking Changes

None for released versions. The error variables were introduced in the pending refactor PR (#54) and have not yet been published in a release. For code tracking the development branch:

- `err == ErrManualRating` still works (same singleton pointers)
- `err.Error()` returns identical messages
- `errors.Is()` now uses code-based matching (more permissive, not less)
- `errors.As()` enables structured error extraction (new capability)

## Related Issues

- Closes #55
- Reserved codes for #58: `ErrCodeInvalidParameters`, `ErrCodeInvalidInput`