### PR TITLE
fix(fsrs): achieve state preservation parity between Forget and Rollback

### DIFF
--- a/forget.go
+++ b/forget.go
@@ -4,21 +4,32 @@ import "time"
 
 // Forget resets a card to the New state. When resetCount is false, the card's
 // Reps and Lapses counters are preserved; otherwise they are zeroed.
-// The returned SchedulingInfo contains the reset card and a Manual review log entry.
+// The returned SchedulingInfo contains the reset card and a Manual review log
+// that captures the card's pre-forget state (State, Due, Stability, Difficulty,
+// ScheduledDays, RemainingSteps). The card's LastReview is preserved.
 func (f *FSRS) Forget(card Card, now time.Time, resetCount bool) SchedulingInfo {
+	scheduledDays := uint64(0)
+	if card.State != New {
+		scheduledDays = dateDiffInDays(now, card.Due)
+	}
+	forgetLog := ReviewLog{
+		Rating:         Manual,
+		State:          card.State,
+		Due:            card.Due,
+		Stability:      card.Stability,
+		Difficulty:     card.Difficulty,
+		ScheduledDays:  scheduledDays,
+		RemainingSteps: card.RemainingSteps,
+		Review:         now,
+	}
 	forgetCard := Card{
-		Due:   now,
-		State: New,
+		Due:        now,
+		State:      New,
+		LastReview: card.LastReview,
 	}
 	if !resetCount {
 		forgetCard.Reps = card.Reps
 		forgetCard.Lapses = card.Lapses
 	}
-	log := ReviewLog{
-		Rating: Manual,
-		State:  New,
-		Due:    now,
-		Review: now,
-	}
-	return SchedulingInfo{Card: forgetCard, ReviewLog: log}
+	return SchedulingInfo{Card: forgetCard, ReviewLog: forgetLog}
 }

--- a/fsrs_test.go
+++ b/fsrs_test.go
@@ -2056,8 +2056,8 @@ func TestForget(t *testing.T) {
 		if result.Card.ScheduledDays != 0 {
 			t.Errorf("expected ScheduledDays=0, got=%d", result.Card.ScheduledDays)
 		}
-		if !result.Card.LastReview.IsZero() {
-			t.Errorf("expected LastReview zero, got=%v", result.Card.LastReview)
+		if result.Card.LastReview != card.LastReview {
+			t.Errorf("expected LastReview=%v, got=%v", card.LastReview, result.Card.LastReview)
 		}
 		if result.Card.RemainingSteps != 0 {
 			t.Errorf("expected RemainingSteps=0, got=%d", result.Card.RemainingSteps)
@@ -2065,26 +2065,23 @@ func TestForget(t *testing.T) {
 		if result.ReviewLog.Rating != Manual {
 			t.Errorf("expected log Rating=Manual, got=%v", result.ReviewLog.Rating)
 		}
-		if result.ReviewLog.State != New {
-			t.Errorf("expected log State=New, got=%v", result.ReviewLog.State)
+		if result.ReviewLog.State != card.State {
+			t.Errorf("expected log State=%v, got=%v", card.State, result.ReviewLog.State)
 		}
-		if result.ReviewLog.Due != now {
-			t.Errorf("expected log Due=now, got=%v", result.ReviewLog.Due)
+		if result.ReviewLog.Due != card.Due {
+			t.Errorf("expected log Due=%v, got=%v", card.Due, result.ReviewLog.Due)
 		}
 		if result.ReviewLog.Review != now {
 			t.Errorf("expected log Review=now, got=%v", result.ReviewLog.Review)
 		}
-		if result.ReviewLog.ScheduledDays != 0 {
-			t.Errorf("expected log ScheduledDays=0, got=%d", result.ReviewLog.ScheduledDays)
+		if result.ReviewLog.Stability != card.Stability {
+			t.Errorf("expected log Stability=%v, got=%v", card.Stability, result.ReviewLog.Stability)
 		}
-		if result.ReviewLog.Stability != 0 {
-			t.Errorf("expected log Stability=0, got=%v", result.ReviewLog.Stability)
+		if result.ReviewLog.Difficulty != card.Difficulty {
+			t.Errorf("expected log Difficulty=%v, got=%v", card.Difficulty, result.ReviewLog.Difficulty)
 		}
-		if result.ReviewLog.Difficulty != 0 {
-			t.Errorf("expected log Difficulty=0, got=%v", result.ReviewLog.Difficulty)
-		}
-		if result.ReviewLog.RemainingSteps != 0 {
-			t.Errorf("expected log RemainingSteps=0, got=%d", result.ReviewLog.RemainingSteps)
+		if result.ReviewLog.RemainingSteps != card.RemainingSteps {
+			t.Errorf("expected log RemainingSteps=%d, got=%d", card.RemainingSteps, result.ReviewLog.RemainingSteps)
 		}
 	})
 
@@ -2111,16 +2108,34 @@ func TestForget(t *testing.T) {
 		if result.Card.ScheduledDays != 0 {
 			t.Errorf("expected ScheduledDays=0, got=%d", result.Card.ScheduledDays)
 		}
-		if !result.Card.LastReview.IsZero() {
-			t.Errorf("expected LastReview zero, got=%v", result.Card.LastReview)
+		if result.Card.LastReview != card.LastReview {
+			t.Errorf("expected LastReview=%v, got=%v", card.LastReview, result.Card.LastReview)
 		}
 		if result.Card.RemainingSteps != 0 {
 			t.Errorf("expected RemainingSteps=0, got=%d", result.Card.RemainingSteps)
 		}
+		if result.ReviewLog.Rating != Manual {
+			t.Errorf("expected log Rating=Manual, got=%v", result.ReviewLog.Rating)
+		}
+		if result.ReviewLog.State != card.State {
+			t.Errorf("expected log State=%v, got=%v", card.State, result.ReviewLog.State)
+		}
+		if result.ReviewLog.Due != card.Due {
+			t.Errorf("expected log Due=%v, got=%v", card.Due, result.ReviewLog.Due)
+		}
+		if result.ReviewLog.Stability != card.Stability {
+			t.Errorf("expected log Stability=%v, got=%v", card.Stability, result.ReviewLog.Stability)
+		}
+		if result.ReviewLog.Difficulty != card.Difficulty {
+			t.Errorf("expected log Difficulty=%v, got=%v", card.Difficulty, result.ReviewLog.Difficulty)
+		}
+		if result.ReviewLog.RemainingSteps != card.RemainingSteps {
+			t.Errorf("expected log RemainingSteps=%d, got=%d", card.RemainingSteps, result.ReviewLog.RemainingSteps)
+		}
 	})
 
 	t.Run("already new", func(t *testing.T) {
-		newCard := NewCard()
+		newCard := NewCard(now)
 		result := fsrs.Forget(newCard, now, false)
 		if result.Card.State != New {
 			t.Errorf("expected State=New, got=%v", result.Card.State)
@@ -2155,6 +2170,18 @@ func TestForget(t *testing.T) {
 		if result.ReviewLog.Review != now {
 			t.Errorf("expected log Review=now, got=%v", result.ReviewLog.Review)
 		}
+		if result.ReviewLog.Stability != 0 {
+			t.Errorf("expected log Stability=0, got=%v", result.ReviewLog.Stability)
+		}
+		if result.ReviewLog.Difficulty != 0 {
+			t.Errorf("expected log Difficulty=0, got=%v", result.ReviewLog.Difficulty)
+		}
+		if result.ReviewLog.ScheduledDays != 0 {
+			t.Errorf("expected log ScheduledDays=0, got=%d", result.ReviewLog.ScheduledDays)
+		}
+		if result.ReviewLog.RemainingSteps != 0 {
+			t.Errorf("expected log RemainingSteps=0, got=%d", result.ReviewLog.RemainingSteps)
+		}
 	})
 
 	t.Run("review state card", func(t *testing.T) {
@@ -2185,20 +2212,82 @@ func TestForget(t *testing.T) {
 		if result.Card.Difficulty != 0 {
 			t.Errorf("expected Difficulty=0, got=%v", result.Card.Difficulty)
 		}
-		if !result.Card.LastReview.IsZero() {
-			t.Errorf("expected LastReview zero, got=%v", result.Card.LastReview)
+		if result.Card.LastReview != reviewCard.LastReview {
+			t.Errorf("expected LastReview=%v, got=%v", reviewCard.LastReview, result.Card.LastReview)
 		}
 		if result.ReviewLog.Rating != Manual {
 			t.Errorf("expected log Rating=Manual, got=%v", result.ReviewLog.Rating)
 		}
-		if result.ReviewLog.State != New {
-			t.Errorf("expected log State=New, got=%v", result.ReviewLog.State)
+		if result.ReviewLog.State != reviewCard.State {
+			t.Errorf("expected log State=%v, got=%v", reviewCard.State, result.ReviewLog.State)
 		}
 		if result.ReviewLog.Due != reviewCard.Due {
 			t.Errorf("expected log Due=%v, got=%v", reviewCard.Due, result.ReviewLog.Due)
 		}
 		if result.ReviewLog.Review != reviewCard.Due {
 			t.Errorf("expected log Review=%v, got=%v", reviewCard.Due, result.ReviewLog.Review)
+		}
+		if result.ReviewLog.Stability != reviewCard.Stability {
+			t.Errorf("expected log Stability=%v, got=%v", reviewCard.Stability, result.ReviewLog.Stability)
+		}
+		if result.ReviewLog.Difficulty != reviewCard.Difficulty {
+			t.Errorf("expected log Difficulty=%v, got=%v", reviewCard.Difficulty, result.ReviewLog.Difficulty)
+		}
+		if result.ReviewLog.RemainingSteps != reviewCard.RemainingSteps {
+			t.Errorf("expected log RemainingSteps=%d, got=%d", reviewCard.RemainingSteps, result.ReviewLog.RemainingSteps)
+		}
+		if result.ReviewLog.ScheduledDays != 0 {
+			t.Errorf("expected log ScheduledDays=0 (Due==now), got=%d", result.ReviewLog.ScheduledDays)
+		}
+	})
+
+	t.Run("log captures pre-forget state", func(t *testing.T) {
+		result := fsrs.Forget(card, now, false)
+		if result.ReviewLog.State != card.State {
+			t.Errorf("expected log State=%v, got=%v", card.State, result.ReviewLog.State)
+		}
+		if result.ReviewLog.Due != card.Due {
+			t.Errorf("expected log Due=%v, got=%v", card.Due, result.ReviewLog.Due)
+		}
+		if result.ReviewLog.Stability != card.Stability {
+			t.Errorf("expected log Stability=%v, got=%v", card.Stability, result.ReviewLog.Stability)
+		}
+		if result.ReviewLog.Difficulty != card.Difficulty {
+			t.Errorf("expected log Difficulty=%v, got=%v", card.Difficulty, result.ReviewLog.Difficulty)
+		}
+		if result.ReviewLog.RemainingSteps != card.RemainingSteps {
+			t.Errorf("expected log RemainingSteps=%d, got=%d", card.RemainingSteps, result.ReviewLog.RemainingSteps)
+		}
+		expectedScheduledDays := uint64(0)
+		if card.State != New {
+			expectedScheduledDays = dateDiffInDays(now, card.Due)
+		}
+		if result.ReviewLog.ScheduledDays != expectedScheduledDays {
+			t.Errorf("expected log ScheduledDays=%d, got=%d", expectedScheduledDays, result.ReviewLog.ScheduledDays)
+		}
+		if result.Card.LastReview != card.LastReview {
+			t.Errorf("expected card LastReview=%v, got=%v", card.LastReview, result.Card.LastReview)
+		}
+		if result.Card.Stability != 0 {
+			t.Errorf("expected card Stability=0, got=%v", result.Card.Stability)
+		}
+		if result.Card.Difficulty != 0 {
+			t.Errorf("expected card Difficulty=0, got=%v", result.Card.Difficulty)
+		}
+		if result.Card.ScheduledDays != 0 {
+			t.Errorf("expected card ScheduledDays=0, got=%d", result.Card.ScheduledDays)
+		}
+		if result.Card.RemainingSteps != 0 {
+			t.Errorf("expected card RemainingSteps=0, got=%d", result.Card.RemainingSteps)
+		}
+	})
+
+	t.Run("log scheduled days with future due", func(t *testing.T) {
+		forgetNow := now.Add(-48 * time.Hour)
+		result := fsrs.Forget(card, forgetNow, false)
+		expectedDays := dateDiffInDays(forgetNow, card.Due)
+		if result.ReviewLog.ScheduledDays != expectedDays {
+			t.Errorf("expected log ScheduledDays=%d, got=%d", expectedDays, result.ReviewLog.ScheduledDays)
 		}
 	})
 }
@@ -2326,7 +2415,7 @@ func TestRollback(t *testing.T) {
 		}
 	})
 
-	t.Run("preserves remaining steps from post-review card", func(t *testing.T) {
+	t.Run("restores remaining steps from log", func(t *testing.T) {
 		card := NewCard()
 		schedulingCards, err := fsrs.Repeat(card, now)
 		if err != nil {
@@ -2341,8 +2430,8 @@ func TestRollback(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if rolledBack.RemainingSteps != result.Card.RemainingSteps {
-			t.Errorf("expected RemainingSteps=%d (from post-review card), got=%d", result.Card.RemainingSteps, rolledBack.RemainingSteps)
+		if rolledBack.RemainingSteps != result.ReviewLog.RemainingSteps {
+			t.Errorf("expected RemainingSteps=%d (from log), got=%d", result.ReviewLog.RemainingSteps, rolledBack.RemainingSteps)
 		}
 	})
 
@@ -2467,6 +2556,45 @@ func TestRollback(t *testing.T) {
 		}
 		if !errors.Is(err, ErrInvalidRating) {
 			t.Errorf("expected ErrInvalidRating, got=%v", err)
+		}
+	})
+
+	t.Run("learning state rollback", func(t *testing.T) {
+		card := NewCard()
+		schedulingCards, err := fsrs.Repeat(card, now)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		learningCard := schedulingCards[Again].Card
+		if learningCard.State != Learning {
+			t.Fatalf("expected Learning state, got=%v", learningCard.State)
+		}
+		schedulingCards2, err := fsrs.Repeat(learningCard, now)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		goodResult := schedulingCards2[Good]
+		rolledBack, err := fsrs.Rollback(goodResult.Card, goodResult.ReviewLog)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if rolledBack.State != Learning {
+			t.Errorf("expected State=Learning, got=%v", rolledBack.State)
+		}
+		if rolledBack.Stability != goodResult.ReviewLog.Stability {
+			t.Errorf("expected Stability=%v, got=%v", goodResult.ReviewLog.Stability, rolledBack.Stability)
+		}
+		if rolledBack.Difficulty != goodResult.ReviewLog.Difficulty {
+			t.Errorf("expected Difficulty=%v, got=%v", goodResult.ReviewLog.Difficulty, rolledBack.Difficulty)
+		}
+		if rolledBack.RemainingSteps != goodResult.ReviewLog.RemainingSteps {
+			t.Errorf("expected RemainingSteps=%d, got=%d", goodResult.ReviewLog.RemainingSteps, rolledBack.RemainingSteps)
+		}
+		if rolledBack.Due != goodResult.ReviewLog.Review {
+			t.Errorf("expected Due=%v, got=%v", goodResult.ReviewLog.Review, rolledBack.Due)
+		}
+		if rolledBack.LastReview != goodResult.ReviewLog.Due {
+			t.Errorf("expected LastReview=%v, got=%v", goodResult.ReviewLog.Due, rolledBack.LastReview)
 		}
 	})
 }

--- a/rollback.go
+++ b/rollback.go
@@ -17,6 +17,7 @@ func (f *FSRS) Rollback(card Card, log ReviewLog) (Card, error) {
 	result.Stability = log.Stability
 	result.Difficulty = log.Difficulty
 	result.ScheduledDays = log.ScheduledDays
+	result.RemainingSteps = log.RemainingSteps
 	if card.Reps > 0 {
 		result.Reps = card.Reps - 1
 	}


### PR DESCRIPTION
## Summary
This PR achieves state preservation parity between the Forget and Rollback operations in the FSRS (Free Spaced Repetition Scheduler). The Forget function now captures the card's full pre-forget state in the review log, and the Rollback function now restores RemainingSteps from the log, ensuring both operations consistently preserve and restore all relevant state information.

## Bug Description
- **What was happening:** The Forget function was not capturing the card's pre-forget state (State, Due, Stability, Difficulty, ScheduledDays, RemainingSteps) in the ReviewLog — instead it recorded only the reset state. The Rollback function restored most fields from the log but omitted RemainingSteps.
- **Expected behavior:** Both Forget and Rollback should preserve and restore the complete card state to maintain operational parity.
- **Root cause:** Forget recorded minimal information in the ReviewLog rather than the card's pre-operation state. Rollback was missing the RemainingSteps restoration logic.

## Changes Made
- **forget.go**: Capture pre-forget State, Due, Stability, Difficulty, ScheduledDays, and RemainingSteps in the ReviewLog; preserve card LastReview.
- **rollback.go**: Add `result.RemainingSteps = log.RemainingSteps` to restore RemainingSteps from the ReviewLog during rollback.
- **fsrs_test.go**: Update existing tests and add new test cases covering pre-state capture, ScheduledDays computation, LastReview preservation, and learning-state rollback.

## Testing
- [x] Tested locally
- [x] Unit tests added/updated
- [x] No regressions

## Related Issues
Fixes #65

## Breaking Changes
None — These are bug fixes correcting incorrect behavior. The public API signatures remain unchanged.