### PR TITLE
fix(parameters): apply sqrt to W[17]/W[18] relearning ceiling with negative-value guard

### DIFF
--- a/fsrs_test.go
+++ b/fsrs_test.go
@@ -704,6 +704,58 @@ func TestNewFSRSDynamicCeiling(t *testing.T) {
 			t.Errorf("W[18]: expected finite after NewFSRS with negative W[11], got=%v", f.W[18])
 		}
 	})
+
+	t.Run("negative value produces finite ceiling via sqrt guard", func(t *testing.T) {
+		p := DefaultParam()
+		p.RelearningSteps = []float64{10, 20}
+		p.W[11] = 5.0
+		p.W[13] = 0.9
+		p.W[14] = 4.0
+		p.W[17] = 1.5
+		p.W[18] = 1.5
+		f := NewFSRS(p)
+
+		// value = -(ln(5) + ln(2^0.9-1) + 4*0.3) / 2 ≈ -1.333
+		// math.Sqrt(math.Max(-1.333, 0)) = sqrt(0) = 0
+		// clamp(0, 0.01, 2.0) = 0.01
+		if math.IsNaN(f.W[17]) || math.IsInf(f.W[17], 0) {
+			t.Errorf("W[17]: expected finite for negative value, got=%v", f.W[17])
+		}
+		if math.IsNaN(f.W[18]) || math.IsInf(f.W[18], 0) {
+			t.Errorf("W[18]: expected finite for negative value, got=%v", f.W[18])
+		}
+		if f.W[17] < 0 || f.W[18] < 0 {
+			t.Errorf("W[17]=%v, W[18]=%v: expected non-negative", f.W[17], f.W[18])
+		}
+	})
+
+	t.Run("W17/W18 ceiling with multiple relearning steps applies square root", func(t *testing.T) {
+		p := DefaultParam()
+		p.RelearningSteps = []float64{10, 20, 30, 40} // len = 4
+		p.W[11] = 0.1
+		p.W[13] = 0.1
+		p.W[14] = 0.5
+		p.W[17] = 2.0
+		p.W[18] = 2.0
+		f := NewFSRS(p)
+
+		// Manual calculation:
+		// w11 = 0.1 -> ln(0.1) ≈ -2.30258509
+		// w13 = 0.1 -> ln(2^0.1 - 1) = ln(1.07177346 - 1) = ln(0.07177346) ≈ -2.63422967
+		// w14 = 0.5 -> w14 * 0.3 = 0.15
+		// sum = -2.30258509 - 2.63422967 + 0.15 = -4.78681476
+		// value = -sum / 4 = 1.19670369
+		// expected ceiling = sqrt(value) ≈ 1.0939395
+		// Without sqrt, the ceiling would be 1.19670369.
+		expectedCeiling := 1.0939395
+		tolerance := 1e-5
+		if math.Abs(f.W[17]-expectedCeiling) > tolerance {
+			t.Errorf("W[17]: expected ceiling ≈ %v (with sqrt), got=%v", expectedCeiling, f.W[17])
+		}
+		if math.Abs(f.W[18]-expectedCeiling) > tolerance {
+			t.Errorf("W[18]: expected ceiling ≈ %v (with sqrt), got=%v", expectedCeiling, f.W[18])
+		}
+	})
 }
 
 func TestNewFSRSW19EnableShortTerm(t *testing.T) {

--- a/fsrs_test.go
+++ b/fsrs_test.go
@@ -682,11 +682,17 @@ func TestNewFSRSDynamicCeiling(t *testing.T) {
 		p.W[17] = 2.5
 		p.W[18] = 2.5
 		f := NewFSRS(p)
-		if f.W[17] > 2.0 {
-			t.Errorf("W[17]: expected <= 2.0 after NewFSRS, got=%v", f.W[17])
+
+		// w11=1.4835, w13=0.2629, w14=1.6483
+		// value = -(ln(1.4835) + ln(2^0.2629-1) + 1.6483*0.3) / 2 ≈ 0.3601
+		// ceiling = sqrt(0.3601) ≈ 0.6001
+		expectedCeiling := 0.6001
+		tolerance := 1e-2
+		if math.Abs(f.W[17]-expectedCeiling) > tolerance {
+			t.Errorf("W[17]: expected ceiling ≈ %v (with sqrt), got=%v", expectedCeiling, f.W[17])
 		}
-		if f.W[18] > 2.0 {
-			t.Errorf("W[18]: expected <= 2.0 after NewFSRS, got=%v", f.W[18])
+		if math.Abs(f.W[18]-expectedCeiling) > tolerance {
+			t.Errorf("W[18]: expected ceiling ≈ %v (with sqrt), got=%v", expectedCeiling, f.W[18])
 		}
 	})
 
@@ -702,6 +708,25 @@ func TestNewFSRSDynamicCeiling(t *testing.T) {
 		}
 		if math.IsNaN(f.W[18]) || math.IsInf(f.W[18], 0) {
 			t.Errorf("W[18]: expected finite after NewFSRS with negative W[11], got=%v", f.W[18])
+		}
+		// W[11]=-1 clamped to 0.001 -> value ≈ 4.011 -> sqrt ≈ 2.003 -> clamped to 2.0
+		if f.W[17] > 2.0 {
+			t.Errorf("W[17]: expected <= 2.0, got=%v", f.W[17])
+		}
+	})
+
+	t.Run("single relearning step uses default ceiling of 2.0", func(t *testing.T) {
+		p := DefaultParam()
+		p.RelearningSteps = []float64{10}
+		p.W[17] = 2.5
+		p.W[18] = 2.5
+		f := NewFSRS(p)
+
+		if f.W[17] > 2.0 {
+			t.Errorf("W[17]: expected <= 2.0 with single step, got=%v", f.W[17])
+		}
+		if f.W[18] > 2.0 {
+			t.Errorf("W[18]: expected <= 2.0 with single step, got=%v", f.W[18])
 		}
 	})
 
@@ -754,6 +779,13 @@ func TestNewFSRSDynamicCeiling(t *testing.T) {
 		}
 		if math.Abs(f.W[18]-expectedCeiling) > tolerance {
 			t.Errorf("W[18]: expected ceiling ≈ %v (with sqrt), got=%v", expectedCeiling, f.W[18])
+		}
+
+		// Verify mathematical constraint: w17 * w18 <= value
+		rawValue := 1.19670369
+		constraintTolerance := 1e-4
+		if f.W[17]*f.W[18] > rawValue+constraintTolerance {
+			t.Errorf("W[17]*W[18] = %v, expected <= %v (raw value)", f.W[17]*f.W[18], rawValue)
 		}
 	})
 }

--- a/parameters.go
+++ b/parameters.go
@@ -96,7 +96,7 @@ func clipParameters(p *Parameters) {
 				math.Log(math.Pow(2.0, w13)-1.0) +
 				w14*0.3) /
 			float64(numRelearning)
-		w17W18Ceiling = clamp(value, 0.01, 2.0)
+		w17W18Ceiling = clamp(math.Sqrt(math.Max(value, 0)), 0.01, 2.0)
 	}
 
 	w19Min := 0.0


### PR DESCRIPTION
## Summary
Fix the dynamic ceiling calculation for W[17] and W[18] by applying `sqrt` and adding a negative-value guard, ensuring `w17 * w18 ≤ value` and preventing NaN.

## Bug Description
- **What was happening:** The ceiling was `clamp(value, 0.01, 2.0)`, so `w17*w18` could reach `value²`, exceeding the theoretical limit. When `value < 0`, `sqrt` produced NaN.
- **Expected behavior:** Ceiling = `sqrt(value)` ensures `ceiling² ≤ value`. Negative values guard to floor 0.01.
- **Root cause:** Missing `sqrt` transformation and no negative-value protection.

## Changes Made
- `parameters.go`: `clamp(value, 0.01, 2.0)` → `clamp(math.Sqrt(math.Max(value, 0)), 0.01, 2.0)`
- `fsrs_test.go`: 5 test cases covering exact ceiling, NaN guard, single step, negative value, and `w17*w18 ≤ value` constraint

## Testing
- [x] Tested locally
- [x] Unit tests added/updated
- [x] No regressions

## Breaking Changes
None — correctness fix. No API changes.