### PR TITLE
feat(fsrs): add v4.5 weights conversion and auto-detection migration

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -10,6 +10,8 @@ const (
 	ErrCodeInvalidRating
 	ErrCodeManualStateRequired
 	ErrCodeManualDueRequired
+	ErrCodeInvalidWeightsLength
+	ErrCodeInvalidWeightsValue
 )
 
 // Error represents a structured FSRS error with a machine-readable code
@@ -68,5 +70,17 @@ var (
 	ErrManualDueRequired = &Error{
 		Code:    ErrCodeManualDueRequired,
 		Message: "fsrs: due is required for manual rating when state is not New",
+	}
+
+	// ErrInvalidWeightsLength is returned when migrating weights with a length other than 17, 19, or 21.
+	ErrInvalidWeightsLength = &Error{
+		Code:    ErrCodeInvalidWeightsLength,
+		Message: "fsrs: invalid weights slice length: must be 17, 19, or 21",
+	}
+
+	// ErrInvalidWeightsValue is returned when any weight parameter is NaN or Inf.
+	ErrInvalidWeightsValue = &Error{
+		Code:    ErrCodeInvalidWeightsValue,
+		Message: "fsrs: invalid weights value: must be finite",
 	}
 )

--- a/fsrs_test.go
+++ b/fsrs_test.go
@@ -4466,9 +4466,9 @@ func TestGetFuzzRange(t *testing.T) {
 
 	t.Run("min never exceeds max", func(t *testing.T) {
 		for _, tc := range []struct {
-			ivl    float64
+			ivl     float64
 			elapsed float64
-			maxIvl float64
+			maxIvl  float64
 		}{
 			{2.5, 0, 36500},
 			{7.0, 0, 36500},
@@ -4482,4 +4482,353 @@ func TestGetFuzzRange(t *testing.T) {
 			}
 		}
 	})
+}
+
+func TestConvertV45WeightsParity(t *testing.T) {
+	v45 := [17]float64{
+		0.4, 0.6, 2.4, 5.8, 4.93, 0.94, 0.86, 0.01, 1.49, 0.14, 0.94, 2.18, 0.05, 0.34, 1.26, 0.29, 2.61,
+	}
+	expected := [21]float64{
+		0.4, 0.6, 2.4, 5.8, 6.81, 0.44675013, 1.36, 0.01, 1.49, 0.14, 0.94, 2.18, 0.05, 0.34, 1.26, 0.29, 2.61, 0.0, 0.0, 0.0, 0.5,
+	}
+
+	w, err := ConvertV45Weights(v45)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	const tolerance = 1e-6
+	for i := 0; i < 21; i++ {
+		if math.Abs(w[i]-expected[i]) > tolerance {
+			t.Errorf("W[%d]: expected ≈ %v, got %v", i, expected[i], w[i])
+		}
+	}
+}
+
+func TestConvertV45WeightsInvalidInput(t *testing.T) {
+	t.Run("NaN input", func(t *testing.T) {
+		v45 := [17]float64{
+			0.4, 0.6, 2.4, 5.8, 4.93, math.NaN(), 0.86, 0.01, 1.49, 0.14, 0.94, 2.18, 0.05, 0.34, 1.26, 0.29, 2.61,
+		}
+		_, err := ConvertV45Weights(v45)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		var fsrsErr *Error
+		if !errors.As(err, &fsrsErr) || fsrsErr.Code != ErrCodeInvalidWeightsValue {
+			t.Errorf("expected ErrCodeInvalidWeightsValue, got=%v", err)
+		}
+		if !errors.Is(err, ErrInvalidWeightsValue) {
+			t.Errorf("expected errors.Is(err, ErrInvalidWeightsValue), got=%v", err)
+		}
+	})
+
+	t.Run("Inf input", func(t *testing.T) {
+		v45 := [17]float64{
+			0.4, 0.6, 2.4, 5.8, 4.93, 0.94, math.Inf(1), 0.01, 1.49, 0.14, 0.94, 2.18, 0.05, 0.34, 1.26, 0.29, 2.61,
+		}
+		_, err := ConvertV45Weights(v45)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		var fsrsErr *Error
+		if !errors.As(err, &fsrsErr) || fsrsErr.Code != ErrCodeInvalidWeightsValue {
+			t.Errorf("expected ErrCodeInvalidWeightsValue, got=%v", err)
+		}
+		if !errors.Is(err, ErrInvalidWeightsValue) {
+			t.Errorf("expected errors.Is(err, ErrInvalidWeightsValue), got=%v", err)
+		}
+	})
+
+	t.Run("finite input producing NaN in conversion", func(t *testing.T) {
+		v45 := [17]float64{
+			0.4, 0.6, 2.4, 5.8, 4.93, -1000.0, 0.86, 0.01, 1.49, 0.14, 0.94, 2.18, 0.05, 0.34, 1.26, 0.29, 2.61,
+		}
+		_, err := ConvertV45Weights(v45)
+		if err == nil {
+			t.Fatal("expected error for conversion-produced NaN, got nil")
+		}
+		var fsrsErr *Error
+		if !errors.As(err, &fsrsErr) || fsrsErr.Code != ErrCodeInvalidWeightsValue {
+			t.Errorf("expected ErrCodeInvalidWeightsValue, got=%v", err)
+		}
+		if !errors.Is(err, ErrInvalidWeightsValue) {
+			t.Errorf("expected errors.Is(err, ErrInvalidWeightsValue), got=%v", err)
+		}
+	})
+
+	t.Run("all-zero input", func(t *testing.T) {
+		v45 := [17]float64{}
+		w, err := ConvertV45Weights(v45)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if w[4] != 0.0 {
+			t.Errorf("expected W[4] = 0.0, got %v", w[4])
+		}
+		if w[5] != 0.0 {
+			t.Errorf("expected W[5] = 0.0, got %v", w[5])
+		}
+		if w[6] != 0.5 {
+			t.Errorf("expected W[6] = 0.5, got %v", w[6])
+		}
+		if w[20] != 0.5 {
+			t.Errorf("expected W[20] = 0.5, got %v", w[20])
+		}
+	})
+}
+
+func TestConvertV45WeightsIndices(t *testing.T) {
+	v45 := [17]float64{
+		0.4, 0.6, 2.4, 5.8, 4.93, 0.94, 0.86, 0.01, 1.49, 0.14, 0.94, 2.18, 0.05, 0.34, 1.26, 0.29, 2.61,
+	}
+
+	w, err := ConvertV45Weights(v45)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// W[0..3] unchanged
+	for i := 0; i < 4; i++ {
+		if w[i] != v45[i] {
+			t.Errorf("W[%d]: expected unchanged %v, got %v", i, v45[i], w[i])
+		}
+	}
+
+	// W[4] = W[5] * 2.0 + W[4]  (order: reads old W[5] before it is overwritten)
+	expectedW4 := v45[5]*2.0 + v45[4]
+	if math.Abs(w[4]-expectedW4) > 1e-6 {
+		t.Errorf("W[4]: expected ≈ %v, got %v", expectedW4, w[4])
+	}
+
+	// W[5] = ln(W[5] * 3.0 + 1.0) / 3.0
+	expectedW5 := math.Log(v45[5]*3.0+1.0) / 3.0
+	if math.Abs(w[5]-expectedW5) > 1e-6 {
+		t.Errorf("W[5]: expected ≈ %v, got %v", expectedW5, w[5])
+	}
+
+	// W[6] = W[6] + 0.5
+	expectedW6 := v45[6] + 0.5
+	if math.Abs(w[6]-expectedW6) > 1e-6 {
+		t.Errorf("W[6]: expected ≈ %v, got %v", expectedW6, w[6])
+	}
+
+	// W[7..16] unchanged
+	for i := 7; i < 17; i++ {
+		if w[i] != v45[i] {
+			t.Errorf("W[%d]: expected unchanged %v, got %v", i, v45[i], w[i])
+		}
+	}
+
+	// W[17..19] = 0.0
+	for i := 17; i < 20; i++ {
+		if w[i] != 0.0 {
+			t.Errorf("W[%d]: expected 0.0, got %v", i, w[i])
+		}
+	}
+
+	// W[20] = fsrs5DefaultDecay (0.5)
+	if w[20] != 0.5 {
+		t.Errorf("W[20]: expected 0.5, got %v", w[20])
+	}
+}
+
+func TestConvertV45WeightsProducesValidFSRS(t *testing.T) {
+	v45 := [17]float64{
+		0.4, 0.6, 2.4, 5.8, 4.93, 0.94, 0.86, 0.01, 1.49, 0.14, 0.94, 2.18, 0.05, 0.34, 1.26, 0.29, 2.61,
+	}
+
+	w, err := ConvertV45Weights(v45)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify converted weights produce a valid FSRS instance
+	p := DefaultParam()
+	p.W = w
+	if err := p.Validate(); err != nil {
+		t.Errorf("converted weights should pass Validate: %v", err)
+	}
+
+	f := NewFSRS(p)
+	card := NewCard()
+	now := time.Now()
+
+	// Verify Repeat works with converted weights
+	result, err := f.Repeat(card, now)
+	if err != nil {
+		t.Errorf("Repeat should work with converted weights: %v", err)
+	}
+	if len(result) != 4 {
+		t.Errorf("expected 4 scheduling cards, got %d", len(result))
+	}
+
+	// Verify GetRetrievability works with converted weights
+	_, err = f.GetRetrievability(card, now)
+	if err != nil {
+		t.Errorf("GetRetrievability should work with converted weights: %v", err)
+	}
+}
+
+func TestMigrateWeights(t *testing.T) {
+	t.Run("length 17 parity", func(t *testing.T) {
+		v17 := []float64{
+			0.4, 0.6, 2.4, 5.8, 4.93, 0.94, 0.86, 0.01, 1.49, 0.14, 0.94, 2.18, 0.05, 0.34, 1.26, 0.29, 2.61,
+		}
+		w, err := MigrateWeights(v17)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(w) != 21 {
+			t.Fatalf("expected length 21, got %d", len(w))
+		}
+		if math.Abs(w[4]-6.81) > 1e-6 {
+			t.Errorf("expected W[4] ≈ 6.81, got %v", w[4])
+		}
+	})
+
+	t.Run("length 19 migration", func(t *testing.T) {
+		v19 := []float64{
+			0.4, 0.6, 2.4, 5.8, 4.93, 0.94, 0.86, 0.01, 1.49, 0.14, 0.94, 2.18, 0.05, 0.34, 1.26, 0.29, 2.61, 1.0, 2.0,
+		}
+		w, err := MigrateWeights(v19)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if w[19] != 0.0 {
+			t.Errorf("expected W[19] = 0.0, got %v", w[19])
+		}
+		if w[20] != 0.5 {
+			t.Errorf("expected W[20] = 0.5, got %v", w[20])
+		}
+	})
+
+	t.Run("length 21 migration", func(t *testing.T) {
+		v21 := make([]float64, 21)
+		for i := 0; i < 21; i++ {
+			v21[i] = float64(i) + 0.1
+		}
+		w, err := MigrateWeights(v21)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		for i := 0; i < 21; i++ {
+			if w[i] != v21[i] {
+				t.Errorf("expected W[%d] = %v, got %v", i, v21[i], w[i])
+			}
+		}
+	})
+
+	t.Run("invalid length", func(t *testing.T) {
+		_, err := MigrateWeights([]float64{1.0, 2.0})
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		var fsrsErr *Error
+		if !errors.As(err, &fsrsErr) || fsrsErr.Code != ErrCodeInvalidWeightsLength {
+			t.Errorf("expected ErrCodeInvalidWeightsLength, got=%v", err)
+		}
+		if !errors.Is(err, ErrInvalidWeightsLength) {
+			t.Errorf("expected errors.Is(err, ErrInvalidWeightsLength), got=%v", err)
+		}
+	})
+
+	t.Run("NaN in slice", func(t *testing.T) {
+		v19 := []float64{
+			0.4, 0.6, 2.4, 5.8, 4.93, 0.94, 0.86, 0.01, 1.49, 0.14, 0.94, 2.18, 0.05, 0.34, 1.26, 0.29, 2.61, 1.0, math.NaN(),
+		}
+		_, err := MigrateWeights(v19)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		var fsrsErr *Error
+		if !errors.As(err, &fsrsErr) || fsrsErr.Code != ErrCodeInvalidWeightsValue {
+			t.Errorf("expected ErrCodeInvalidWeightsValue, got=%v", err)
+		}
+		if !errors.Is(err, ErrInvalidWeightsValue) {
+			t.Errorf("expected errors.Is(err, ErrInvalidWeightsValue), got=%v", err)
+		}
+	})
+
+	t.Run("Inf in length 19 slice", func(t *testing.T) {
+		v19 := []float64{
+			0.4, 0.6, 2.4, 5.8, 4.93, 0.94, 0.86, 0.01, 1.49, 0.14, 0.94, 2.18, 0.05, 0.34, 1.26, 0.29, 2.61, 1.0, math.Inf(1),
+		}
+		_, err := MigrateWeights(v19)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		var fsrsErr *Error
+		if !errors.As(err, &fsrsErr) || fsrsErr.Code != ErrCodeInvalidWeightsValue {
+			t.Errorf("expected ErrCodeInvalidWeightsValue, got=%v", err)
+		}
+		if !errors.Is(err, ErrInvalidWeightsValue) {
+			t.Errorf("expected errors.Is(err, ErrInvalidWeightsValue), got=%v", err)
+		}
+	})
+
+	t.Run("NaN in length 21 slice", func(t *testing.T) {
+		v21 := make([]float64, 21)
+		for i := range v21 {
+			v21[i] = float64(i) + 0.1
+		}
+		v21[20] = math.NaN()
+		_, err := MigrateWeights(v21)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		var fsrsErr *Error
+		if !errors.As(err, &fsrsErr) || fsrsErr.Code != ErrCodeInvalidWeightsValue {
+			t.Errorf("expected ErrCodeInvalidWeightsValue, got=%v", err)
+		}
+		if !errors.Is(err, ErrInvalidWeightsValue) {
+			t.Errorf("expected errors.Is(err, ErrInvalidWeightsValue), got=%v", err)
+		}
+	})
+
+	t.Run("empty slice", func(t *testing.T) {
+		_, err := MigrateWeights([]float64{})
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		var fsrsErr *Error
+		if !errors.As(err, &fsrsErr) || fsrsErr.Code != ErrCodeInvalidWeightsLength {
+			t.Errorf("expected ErrCodeInvalidWeightsLength, got=%v", err)
+		}
+		if !errors.Is(err, ErrInvalidWeightsLength) {
+			t.Errorf("expected errors.Is(err, ErrInvalidWeightsLength), got=%v", err)
+		}
+	})
+
+	t.Run("sentinels are distinguishable", func(t *testing.T) {
+		_, lengthErr := MigrateWeights([]float64{})
+		_, valueErr := MigrateWeights([]float64{
+			0.4, 0.6, 2.4, 5.8, 4.93, 0.94, 0.86, 0.01, 1.49, 0.14, 0.94, 2.18, 0.05, 0.34, 1.26, 0.29, math.NaN(),
+		})
+
+		if errors.Is(lengthErr, ErrInvalidWeightsValue) {
+			t.Error("length error should NOT match ErrInvalidWeightsValue")
+		}
+		if errors.Is(valueErr, ErrInvalidWeightsLength) {
+			t.Error("value error should NOT match ErrInvalidWeightsLength")
+		}
+	})
+}
+
+func TestConvertV5Weights(t *testing.T) {
+	v5 := [19]float64{
+		0.4, 0.6, 2.4, 5.8, 6.81, 0.44675013, 1.36, 0.01, 1.49, 0.14, 0.94, 2.18, 0.05, 0.34, 1.26, 0.29, 2.61, 1.0, 2.0,
+	}
+	w := ConvertV5Weights(v5)
+	for i := 0; i < 19; i++ {
+		if w[i] != v5[i] {
+			t.Errorf("W[%d]: expected %v, got %v", i, v5[i], w[i])
+		}
+	}
+	if w[19] != 0.0 {
+		t.Errorf("W[19]: expected 0.0, got %v", w[19])
+	}
+	if w[20] != 0.5 {
+		t.Errorf("W[20]: expected 0.5, got %v", w[20])
+	}
 }

--- a/weights.go
+++ b/weights.go
@@ -43,14 +43,21 @@ func ConvertV5Weights(v5 [19]float64) Weights {
 
 const fsrs5DefaultDecay = 0.5
 
+func validateFiniteWeights(weights []float64) error {
+	for _, val := range weights {
+		if math.IsNaN(val) || math.IsInf(val, 0) {
+			return ErrInvalidWeightsValue
+		}
+	}
+	return nil
+}
+
 // ConvertV45Weights converts FSRS v4.5 [17]float64 weights to v6 [21]float64 weights.
 // Returns an error if any input parameter is non-finite (NaN or Inf), or if the converted
 // weights are non-finite.
 func ConvertV45Weights(v45 [17]float64) (Weights, error) {
-	for _, val := range v45 {
-		if math.IsNaN(val) || math.IsInf(val, 0) {
-			return Weights{}, ErrInvalidWeightsValue
-		}
+	if err := validateFiniteWeights(v45[:]); err != nil {
+		return Weights{}, err
 	}
 
 	var w Weights
@@ -66,10 +73,8 @@ func ConvertV45Weights(v45 [17]float64) (Weights, error) {
 	w[19] = 0.0
 	w[20] = fsrs5DefaultDecay
 
-	for _, val := range w {
-		if math.IsNaN(val) || math.IsInf(val, 0) {
-			return Weights{}, ErrInvalidWeightsValue
-		}
+	if err := validateFiniteWeights(w[:]); err != nil {
+		return Weights{}, err
 	}
 
 	return w, nil
@@ -85,23 +90,19 @@ func MigrateWeights(weights []float64) (Weights, error) {
 		copy(v45[:], weights)
 		return ConvertV45Weights(v45)
 	case 19:
-		for _, val := range weights {
-			if math.IsNaN(val) || math.IsInf(val, 0) {
-				return Weights{}, ErrInvalidWeightsValue
-			}
+		if err := validateFiniteWeights(weights); err != nil {
+			return Weights{}, err
 		}
 		var v5 [19]float64
 		copy(v5[:], weights)
 		w := ConvertV5Weights(v5)
 		return w, nil
 	case 21:
-		var w Weights
-		for i, val := range weights {
-			if math.IsNaN(val) || math.IsInf(val, 0) {
-				return Weights{}, ErrInvalidWeightsValue
-			}
-			w[i] = val
+		if err := validateFiniteWeights(weights); err != nil {
+			return Weights{}, err
 		}
+		var w Weights
+		copy(w[:], weights)
 		return w, nil
 	default:
 		return Weights{}, ErrInvalidWeightsLength

--- a/weights.go
+++ b/weights.go
@@ -1,5 +1,7 @@
 package fsrs
 
+import "math"
+
 type Weights [21]float64
 
 func DefaultWeights() Weights {
@@ -35,6 +37,73 @@ func ConvertV5Weights(v5 [19]float64) Weights {
 	var w Weights
 	copy(w[:19], v5[:])
 	w[19] = 0.0
-	w[20] = 0.5
+	w[20] = fsrs5DefaultDecay
 	return w
+}
+
+const fsrs5DefaultDecay = 0.5
+
+// ConvertV45Weights converts FSRS v4.5 [17]float64 weights to v6 [21]float64 weights.
+// Returns an error if any input parameter is non-finite (NaN or Inf), or if the converted
+// weights are non-finite.
+func ConvertV45Weights(v45 [17]float64) (Weights, error) {
+	for _, val := range v45 {
+		if math.IsNaN(val) || math.IsInf(val, 0) {
+			return Weights{}, ErrInvalidWeightsValue
+		}
+	}
+
+	var w Weights
+	copy(w[:17], v45[:])
+
+	// Convert difficulty parameters matching fsrs-rs model.rs:319-325
+	w[4] = w[5]*2.0 + w[4]
+	w[5] = math.Log(w[5]*3.0+1.0) / 3.0
+	w[6] += 0.5
+
+	w[17] = 0.0
+	w[18] = 0.0
+	w[19] = 0.0
+	w[20] = fsrs5DefaultDecay
+
+	for _, val := range w {
+		if math.IsNaN(val) || math.IsInf(val, 0) {
+			return Weights{}, ErrInvalidWeightsValue
+		}
+	}
+
+	return w, nil
+}
+
+// MigrateWeights automatically detects the version of the input weights slice based
+// on its length (17, 19, or 21) and converts it to the current FSRS v6 format.
+// Returns an error if the length is invalid or if any weight is non-finite (NaN/Inf).
+func MigrateWeights(weights []float64) (Weights, error) {
+	switch len(weights) {
+	case 17:
+		var v45 [17]float64
+		copy(v45[:], weights)
+		return ConvertV45Weights(v45)
+	case 19:
+		for _, val := range weights {
+			if math.IsNaN(val) || math.IsInf(val, 0) {
+				return Weights{}, ErrInvalidWeightsValue
+			}
+		}
+		var v5 [19]float64
+		copy(v5[:], weights)
+		w := ConvertV5Weights(v5)
+		return w, nil
+	case 21:
+		var w Weights
+		for i, val := range weights {
+			if math.IsNaN(val) || math.IsInf(val, 0) {
+				return Weights{}, ErrInvalidWeightsValue
+			}
+			w[i] = val
+		}
+		return w, nil
+	default:
+		return Weights{}, ErrInvalidWeightsLength
+	}
 }


### PR DESCRIPTION
## Summary

Add FSRS v4.5 weights conversion (`ConvertV45Weights`) and a top-level `MigrateWeights` function that auto-detects the weight version (v4.5/v5/v6) by slice length and converts seamlessly to the current v6 format.

## Motivation

Users migrating from older FSRS versions (v4.5 or v5) have weight arrays of different lengths (17 or 19) that are incompatible with the current v6 `Weights` type (21 entries). Previously they would need to manually pad and transform weights. With these changes, callers can pass any legacy weight slice to `MigrateWeights` and get a valid v6 weight set back, with automatic version detection and the same conversion formulas used by `fsrs-rs`.

## Changes Made

- **`ConvertV45Weights([17]float64) (Weights, error)`** — Converts FSRS v4.5 (17-weight) arrays to v6 (21-weight), applying the exact `fsrs-rs` transformations: `w[4] = w[5]*2 + w[4]`, `w[5] = ln(w[5]*3+1)/3`, `w[6] += 0.5`, and filling new entries `w[17..19] = 0.0`, `w[20] = 0.5`. Returns `ErrInvalidWeightsValue` on NaN/Inf input or output.
- **`MigrateWeights([]float64) (Weights, error)`** — Auto-detects the weight version by slice length (17→v4.5, 19→v5, 21→identity/validation) and delegates to the appropriate converter. Returns `ErrInvalidWeightsLength` for any other length.
- **New sentinel errors** — `ErrInvalidWeightsLength` and `ErrInvalidWeightsValue` added to `errors.go` with distinct error codes (`ErrCodeInvalidWeightsLength`, `ErrCodeInvalidWeightsValue`) for precise `errors.Is`/`errors.As` matching.
- **Minor refactor** — Extracted `fsrs5DefaultDecay` constant (0.5) in `weights.go` shared by both `ConvertV5Weights` and `ConvertV45Weights`.

## Testing
- [x] Tested locally
- [x] Unit tests added
- [ ] Documentation updated

## Breaking Changes

None. The new functions are additive — no existing APIs are modified or removed. `ConvertV5Weights` was updated to use the `fsrs5DefaultDecay` constant but its external signature and behavior are unchanged.