### PR TITLE
refactor(core): deduplicate interval formula and fuzz logic

### DIFF
--- a/arithmetic.go
+++ b/arithmetic.go
@@ -53,10 +53,14 @@ func (p *Parameters) initDifficulty(r Rating) float64 {
 	return p.W[4] - math.Exp(p.W[5]*float64(r-1)) + 1
 }
 
+func stabilityToInterval(s, decay, factor, retention float64) float64 {
+	return s / factor * (math.Pow(retention, 1/decay) - 1)
+}
+
 func (p *Parameters) nextInterval(s, elapsedDays float64) float64 {
 	decay, factor := p.decayAndFactor()
 	s = constrainStability(s)
-	newInterval := s / factor * (math.Pow(p.RequestRetention, 1/decay) - 1)
+	newInterval := stabilityToInterval(s, decay, factor, p.RequestRetention)
 	interval := max(min(math.Round(newInterval), p.MaximumInterval), 1)
 	if !p.EnableFuzz || interval < 2.5 {
 		return interval
@@ -67,7 +71,7 @@ func (p *Parameters) nextInterval(s, elapsedDays float64) float64 {
 func (p *Parameters) nextIntervalRaw(s float64) float64 {
 	decay, factor := p.decayAndFactor()
 	s = constrainStability(s)
-	return s / factor * (math.Pow(p.RequestRetention, 1/decay) - 1)
+	return stabilityToInterval(s, decay, factor, p.RequestRetention)
 }
 
 func (p *Parameters) nextDifficulty(d float64, r Rating) float64 {

--- a/arithmetic_test.go
+++ b/arithmetic_test.go
@@ -34,6 +34,13 @@ func TestStabilityToInterval(t *testing.T) {
 		}
 	})
 
+	t.Run("retention approaching zero yields +Inf", func(t *testing.T) {
+		got := stabilityToInterval(10.0, decay, factor, 1e-300)
+		if !math.IsInf(got, 1) {
+			t.Errorf("stabilityToInterval at retention→0+ = %v, want +Inf", got)
+		}
+	})
+
 	t.Run("monotonic in stability", func(t *testing.T) {
 		prev := stabilityToInterval(0.001, decay, factor, 0.9)
 		for s := 0.01; s <= 100.0; s *= 1.5 {

--- a/arithmetic_test.go
+++ b/arithmetic_test.go
@@ -1,0 +1,66 @@
+package fsrs
+
+import (
+	"math"
+	"testing"
+)
+
+func TestStabilityToInterval(t *testing.T) {
+	p := DefaultParam()
+	decay, factor := p.decayAndFactor()
+
+	t.Run("typical stability produces finite positive interval", func(t *testing.T) {
+		for _, s := range []float64{0.212, 1.0, 10.0, 100.0} {
+			got := stabilityToInterval(s, decay, factor, 0.9)
+			if got <= 0 || math.IsNaN(got) || math.IsInf(got, 0) {
+				t.Errorf("stabilityToInterval(%v) = %v, want finite positive", s, got)
+			}
+		}
+	})
+
+	t.Run("boundary stability sMin and sMax produce finite positive", func(t *testing.T) {
+		for _, s := range []float64{sMin, sMax} {
+			got := stabilityToInterval(s, decay, factor, 0.9)
+			if got <= 0 || math.IsNaN(got) || math.IsInf(got, 0) {
+				t.Errorf("stabilityToInterval(%v) = %v, want finite positive", s, got)
+			}
+		}
+	})
+
+	t.Run("retention=1.0 yields zero interval", func(t *testing.T) {
+		got := stabilityToInterval(10.0, decay, factor, 1.0)
+		if got != 0.0 {
+			t.Errorf("stabilityToInterval at retention=1.0 = %v, want 0", got)
+		}
+	})
+
+	t.Run("monotonic in stability", func(t *testing.T) {
+		prev := stabilityToInterval(0.001, decay, factor, 0.9)
+		for s := 0.01; s <= 100.0; s *= 1.5 {
+			cur := stabilityToInterval(s, decay, factor, 0.9)
+			if cur <= prev {
+				t.Errorf("not monotonic at s=%v: prev=%v cur=%v", s, prev, cur)
+			}
+			prev = cur
+		}
+	})
+
+	t.Run("inverse of SM2 stability computation", func(t *testing.T) {
+		s := 10.0
+		retention := 0.9
+		interval := stabilityToInterval(s, decay, factor, retention)
+		recovered := interval * factor / (math.Pow(retention, 1/decay) - 1)
+		if math.Abs(recovered-s) > 1e-9 {
+			t.Errorf("round-trip failed: started s=%v, recovered=%v", s, recovered)
+		}
+	})
+
+	t.Run("matches nextIntervalRaw for same retention", func(t *testing.T) {
+		s := 5.0
+		raw := stabilityToInterval(s, decay, factor, p.RequestRetention)
+		fromMethod := p.nextIntervalRaw(s)
+		if math.Abs(raw-fromMethod) > 1e-15 {
+			t.Errorf("stabilityToInterval=%v != nextIntervalRaw=%v", raw, fromMethod)
+		}
+	})
+}

--- a/fuzz.go
+++ b/fuzz.go
@@ -29,13 +29,7 @@ func (p *Parameters) ApplyFuzz(interval float64, elapsedDays float64, enableFuzz
 	if !enableFuzz || interval < 2.5 {
 		return interval
 	}
-
-	generator := Alea(p.seed)
-	fuzzFactor := generator.Double()
-
-	minInterval, maxInterval := getFuzzRange(interval, elapsedDays, p.MaximumInterval)
-
-	return math.Floor(fuzzFactor*float64(maxInterval-minInterval+1)) + float64(minInterval)
+	return applyFuzz(interval, elapsedDays, p.MaximumInterval, p.seed)
 }
 
 func applyFuzz(interval float64, elapsedDays float64, maximumInterval float64, seed string) float64 {

--- a/parameters.go
+++ b/parameters.go
@@ -184,7 +184,7 @@ func (p *Parameters) nextStateInner(current *MemoryState, desiredRetention, elap
 	}
 
 	newS = constrainStability(newS)
-	interval := newS / factor * (math.Pow(desiredRetention, 1/decay) - 1)
+	interval := stabilityToInterval(newS, decay, factor, desiredRetention)
 
 	return ItemState{
 		Memory:   MemoryState{Stability: newS, Difficulty: newD},


### PR DESCRIPTION
## Summary
A pure refactor that deduplicates two formulas used across the FSRS scheduler implementation: the interval computation and the fuzz application logic. Both are internal DRY cleanups with no public API changes.

## Motivation
The FSRS interval formula `s / factor * (pow(retention, 1/decay) - 1)` was copy-pasted across three call sites (`nextInterval`, `nextIntervalRaw`, and `nextStateInner`), and the fuzz calculation inside `ApplyFuzz` was also duplicated as inline logic. This duplication creates a maintenance hazard—any formula correction would need to be applied consistently in every location. These refactors consolidate the logic into single, named helpers so future adjustments are made in one place.

## Changes Made
- Extracted `stabilityToInterval(s, decay, factor, retention float64)` in `arithmetic.go` and delegated `nextInterval` and `nextIntervalRaw` to it; also updated `nextStateInner` in `parameters.go` to call the new helper, eliminating three copies of the interval formula.
- Refactored `ApplyFuzz` in `fuzz.go` to delegate to the existing unexported `applyFuzz` helper, removing the inline fuzz-calculation duplication.
- Added `arithmetic_test.go` with `TestStabilityToInterval` (6 subtests) verifying finiteness, boundary stability values, retention=1.0 yielding zero interval, monotonicity, round-trip inversion correctness, and consistency with `nextIntervalRaw`.

## Impact
- No functional changes
- Performance: same
- Code quality: improved—centralized interval formula and fuzz application into single helper functions; new targeted test coverage for the extracted helper

## Testing
- [x] All existing tests pass
- [x] No behavioral changes

## Related Issues
- Closes #71 — consolidate duplicated fuzz logic between `ApplyFuzz` and `applyFuzz`
- Closes #78 — consolidate FSRS interval formula duplicated across `nextInterval`, `nextIntervalRaw`, and `nextStateInner`

---

<!-- start-auto-generated -->
This is an auto-generated description by sintesitech[bot]

This PR eliminates duplicated FSRS interval formula and fuzz logic by extracting shared helpers: `stabilityToInterval` in `arithmetic.go` and delegating `ApplyFuzz` to the existing unexported `applyFuzz`. The interval formula was previously copy-pasted across three call sites and the fuzz calculation was inlined separately. New targeted tests verify the extracted helper's correctness. This is a pure refactor with no functional or performance changes.

---
<sup>Written for commit 6693cd5a11e8cd678950941136d03ca3e4a695ac. Summary will update on new commits.</sup>
<!-- end-auto-generated -->