### PR TITLE
refactor(api): standardize input validation and structured errors across public API

### DIFF
--- a/forget.go
+++ b/forget.go
@@ -7,7 +7,12 @@ import "time"
 // The returned SchedulingInfo contains the reset card and a Manual review log
 // that captures the card's pre-forget state (State, Due, Stability, Difficulty,
 // ScheduledDays, RemainingSteps). The card's LastReview is preserved.
-func (f *FSRS) Forget(card Card, now time.Time, resetCount bool) SchedulingInfo {
+// Returns an error if the card or current time is invalid.
+func (f *FSRS) Forget(card Card, now time.Time, resetCount bool) (SchedulingInfo, error) {
+	if err := validateCard(card, now); err != nil {
+		return SchedulingInfo{}, err
+	}
+
 	scheduledDays := uint64(0)
 	if card.State != New {
 		scheduledDays = dateDiffInDays(now, card.Due)
@@ -31,5 +36,5 @@ func (f *FSRS) Forget(card Card, now time.Time, resetCount bool) SchedulingInfo 
 		forgetCard.Reps = card.Reps
 		forgetCard.Lapses = card.Lapses
 	}
-	return SchedulingInfo{Card: forgetCard, ReviewLog: forgetLog}
+	return SchedulingInfo{Card: forgetCard, ReviewLog: forgetLog}, nil
 }

--- a/forget_test.go
+++ b/forget_test.go
@@ -1,6 +1,8 @@
 package fsrs
 
 import (
+	"errors"
+	"math"
 	"testing"
 	"time"
 )
@@ -26,7 +28,10 @@ func TestForget(t *testing.T) {
 	}
 
 	t.Run("preserves counters", func(t *testing.T) {
-		result := fsrs.Forget(card, now, false)
+		result, err := fsrs.Forget(card, now, false)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 		if result.Card.State != New {
 			t.Errorf("expected State=New, got=%v", result.Card.State)
 		}
@@ -78,7 +83,10 @@ func TestForget(t *testing.T) {
 	})
 
 	t.Run("resets counters", func(t *testing.T) {
-		result := fsrs.Forget(card, now, true)
+		result, err := fsrs.Forget(card, now, true)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 		if result.Card.State != New {
 			t.Errorf("expected State=New, got=%v", result.Card.State)
 		}
@@ -128,7 +136,10 @@ func TestForget(t *testing.T) {
 
 	t.Run("already new", func(t *testing.T) {
 		newCard := NewCard(now)
-		result := fsrs.Forget(newCard, now, false)
+		result, err := fsrs.Forget(newCard, now, false)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 		if result.Card.State != New {
 			t.Errorf("expected State=New, got=%v", result.Card.State)
 		}
@@ -185,7 +196,10 @@ func TestForget(t *testing.T) {
 		if reviewCard.State != Learning && reviewCard.State != Review {
 			t.Fatalf("expected Learning or Review, got=%v", reviewCard.State)
 		}
-		result := fsrs.Forget(reviewCard, reviewCard.Due, false)
+		result, err := fsrs.Forget(reviewCard, reviewCard.Due, false)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 		if result.Card.State != New {
 			t.Errorf("expected State=New, got=%v", result.Card.State)
 		}
@@ -234,7 +248,10 @@ func TestForget(t *testing.T) {
 	})
 
 	t.Run("log captures pre-forget state", func(t *testing.T) {
-		result := fsrs.Forget(card, now, false)
+		result, err := fsrs.Forget(card, now, false)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 		if result.ReviewLog.State != card.State {
 			t.Errorf("expected log State=%v, got=%v", card.State, result.ReviewLog.State)
 		}
@@ -275,11 +292,68 @@ func TestForget(t *testing.T) {
 	})
 
 	t.Run("log scheduled days with future due", func(t *testing.T) {
-		forgetNow := now.Add(-48 * time.Hour)
-		result := fsrs.Forget(card, forgetNow, false)
+		// now is after card.LastReview but before card.Due — valid, and
+		// the log should capture the remaining scheduled days.
+		forgetNow := card.LastReview.Add(1 * time.Hour)
+		result, err := fsrs.Forget(card, forgetNow, false)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 		expectedDays := dateDiffInDays(forgetNow, card.Due)
 		if result.ReviewLog.ScheduledDays != expectedDays {
 			t.Errorf("expected log ScheduledDays=%d, got=%d", expectedDays, result.ReviewLog.ScheduledDays)
+		}
+	})
+
+	t.Run("rejects now before LastReview", func(t *testing.T) {
+		// now before LastReview violates the invariant enforced by validateCard.
+		forgetNow := card.LastReview.Add(-48 * time.Hour)
+		_, err := fsrs.Forget(card, forgetNow, false)
+		if err == nil {
+			t.Fatal("expected error for now before LastReview, got nil")
+		}
+		var fsrsErr *Error
+		if !errors.As(err, &fsrsErr) || fsrsErr.Code != ErrCodeInvalidInput {
+			t.Errorf("expected ErrCodeInvalidInput, got=%v", err)
+		}
+	})
+
+	t.Run("rejects invalid card state", func(t *testing.T) {
+		badCard := card
+		badCard.State = State(99)
+		_, err := fsrs.Forget(badCard, now, false)
+		if err == nil {
+			t.Fatal("expected error for invalid state, got nil")
+		}
+		var fsrsErr *Error
+		if !errors.As(err, &fsrsErr) || fsrsErr.Code != ErrCodeInvalidInput {
+			t.Errorf("expected ErrCodeInvalidInput, got=%v", err)
+		}
+	})
+
+	t.Run("rejects NaN stability", func(t *testing.T) {
+		badCard := card
+		badCard.Stability = math.NaN()
+		_, err := fsrs.Forget(badCard, now, false)
+		if err == nil {
+			t.Fatal("expected error for NaN stability, got nil")
+		}
+		var fsrsErr *Error
+		if !errors.As(err, &fsrsErr) || fsrsErr.Code != ErrCodeInvalidInput {
+			t.Errorf("expected ErrCodeInvalidInput, got=%v", err)
+		}
+	})
+
+	t.Run("rejects NaN difficulty", func(t *testing.T) {
+		badCard := card
+		badCard.Difficulty = math.NaN()
+		_, err := fsrs.Forget(badCard, now, false)
+		if err == nil {
+			t.Fatal("expected error for NaN difficulty, got nil")
+		}
+		var fsrsErr *Error
+		if !errors.As(err, &fsrsErr) || fsrsErr.Code != ErrCodeInvalidInput {
+			t.Errorf("expected ErrCodeInvalidInput, got=%v", err)
 		}
 	})
 }

--- a/memory.go
+++ b/memory.go
@@ -7,7 +7,7 @@ import (
 
 func (f *FSRS) computeMemoryStates(history ReviewEntries, startingState *MemoryState, returnAll bool) ([]MemoryState, error) {
 	if len(history) == 0 {
-		return nil, fmt.Errorf("fsrs: history must not be empty")
+		return nil, &Error{Code: ErrCodeInvalidInput, Message: "fsrs: history must not be empty"}
 	}
 
 	decay, factor := f.decayAndFactor()
@@ -27,10 +27,10 @@ func (f *FSRS) computeMemoryStates(history ReviewEntries, startingState *MemoryS
 
 	for _, review := range history {
 		if review.Rating < Again || review.Rating > Easy {
-			return nil, fmt.Errorf("fsrs: invalid rating %d, must be 1-4", review.Rating)
+			return nil, &Error{Code: ErrCodeInvalidInput, Message: fmt.Sprintf("fsrs: invalid rating %d, must be 1-4", review.Rating)}
 		}
 		if review.DeltaT < 0 || math.IsNaN(review.DeltaT) || math.IsInf(review.DeltaT, 0) {
-			return nil, fmt.Errorf("fsrs: invalid delta_t, must be a finite non-negative number")
+			return nil, &Error{Code: ErrCodeInvalidInput, Message: "fsrs: invalid delta_t, must be a finite non-negative number"}
 		}
 
 		item := f.nextStateInner(&MemoryState{
@@ -45,10 +45,10 @@ func (f *FSRS) computeMemoryStates(history ReviewEntries, startingState *MemoryS
 	}
 
 	if math.IsNaN(cur.Stability) || math.IsInf(cur.Stability, 0) {
-		return nil, fmt.Errorf("fsrs: computed stability is not finite")
+		return nil, &Error{Code: ErrCodeInvalidInput, Message: "fsrs: computed stability is not finite"}
 	}
 	if math.IsNaN(cur.Difficulty) || math.IsInf(cur.Difficulty, 0) {
-		return nil, fmt.Errorf("fsrs: computed difficulty is not finite")
+		return nil, &Error{Code: ErrCodeInvalidInput, Message: "fsrs: computed difficulty is not finite"}
 	}
 
 	if returnAll {
@@ -79,13 +79,13 @@ func (f *FSRS) HistoricalMemoryStates(history ReviewEntries, startingState *Memo
 // sm2Retention must be finite and in (0, 1) exclusive.
 func (f *FSRS) MemoryStateFromSM2(easeFactor, interval, sm2Retention float64) (*MemoryState, error) {
 	if !isFinite(easeFactor) || easeFactor <= 1 {
-		return nil, fmt.Errorf("fsrs: invalid easeFactor: %v (must be finite and > 1)", easeFactor)
+		return nil, &Error{Code: ErrCodeInvalidInput, Message: fmt.Sprintf("fsrs: invalid easeFactor: %v (must be finite and > 1)", easeFactor)}
 	}
 	if !isFinite(interval) || interval < 0 {
-		return nil, fmt.Errorf("fsrs: invalid interval: %v (must be a finite non-negative number)", interval)
+		return nil, &Error{Code: ErrCodeInvalidInput, Message: fmt.Sprintf("fsrs: invalid interval: %v (must be a finite non-negative number)", interval)}
 	}
 	if !isFinite(sm2Retention) || sm2Retention <= 0 || sm2Retention >= 1 {
-		return nil, fmt.Errorf("fsrs: invalid sm2Retention: %v (must be finite and in (0, 1))", sm2Retention)
+		return nil, &Error{Code: ErrCodeInvalidInput, Message: fmt.Sprintf("fsrs: invalid sm2Retention: %v (must be finite and in (0, 1))", sm2Retention)}
 	}
 
 	decay, factor := f.decayAndFactor()
@@ -100,7 +100,7 @@ func (f *FSRS) MemoryStateFromSM2(easeFactor, interval, sm2Retention float64) (*
 		(math.Exp(w8)*math.Pow(stability, -w9)*math.Expm1((1-sm2Retention)*w10))
 
 	if !isFinite(stability) || !isFinite(difficulty) {
-		return nil, fmt.Errorf("fsrs: computed memory state is not finite (stability=%v, difficulty=%v)", stability, difficulty)
+		return nil, &Error{Code: ErrCodeInvalidInput, Message: fmt.Sprintf("fsrs: computed memory state is not finite (stability=%v, difficulty=%v)", stability, difficulty)}
 	}
 
 	return &MemoryState{

--- a/memory_test.go
+++ b/memory_test.go
@@ -1,6 +1,7 @@
 package fsrs
 
 import (
+	"errors"
 	"math"
 	"testing"
 	"time"
@@ -291,40 +292,37 @@ func TestMemoryStateMatchesRepeatSchedule(t *testing.T) {
 func TestMemoryStateInvalidInput(t *testing.T) {
 	f := NewFSRS(DefaultParam())
 
-	_, err := f.MemoryState(ReviewEntries{}, nil)
-	if err == nil {
-		t.Error("empty history should return error")
+	assertInvalidInput := func(t *testing.T, err error) {
+		t.Helper()
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		var fsrsErr *Error
+		if !errors.As(err, &fsrsErr) || fsrsErr.Code != ErrCodeInvalidInput {
+			t.Errorf("expected ErrCodeInvalidInput, got=%v", err)
+		}
 	}
+
+	_, err := f.MemoryState(ReviewEntries{}, nil)
+	assertInvalidInput(t, err)
 
 	_, err = f.MemoryState(ReviewEntries{{Rating: 0, DeltaT: 1}}, nil)
-	if err == nil {
-		t.Error("rating 0 should return error")
-	}
+	assertInvalidInput(t, err)
 
 	_, err = f.MemoryState(ReviewEntries{{Rating: 5, DeltaT: 1}}, nil)
-	if err == nil {
-		t.Error("rating 5 should return error")
-	}
+	assertInvalidInput(t, err)
 
 	_, err = f.MemoryState(ReviewEntries{{Rating: Good, DeltaT: -1}}, nil)
-	if err == nil {
-		t.Error("negative delta_t should return error")
-	}
+	assertInvalidInput(t, err)
 
 	_, err = f.MemoryState(ReviewEntries{{Rating: Good, DeltaT: math.NaN()}}, nil)
-	if err == nil {
-		t.Error("NaN delta_t should return error")
-	}
+	assertInvalidInput(t, err)
 
 	_, err = f.MemoryState(ReviewEntries{{Rating: Good, DeltaT: math.Inf(1)}}, nil)
-	if err == nil {
-		t.Error("Inf delta_t should return error")
-	}
+	assertInvalidInput(t, err)
 
 	_, err = f.HistoricalMemoryStates(ReviewEntries{}, nil)
-	if err == nil {
-		t.Error("empty history should return error")
-	}
+	assertInvalidInput(t, err)
 }
 
 func TestMemoryStateSingleReviewFromNew(t *testing.T) {
@@ -351,11 +349,11 @@ func TestMemoryStateFromSM2(t *testing.T) {
 	f := NewFSRS(DefaultParam())
 
 	cases := []struct {
-		ease             float64
-		interval         float64
-		retention        float64
-		wantStability    float64
-		wantDifficulty   float64
+		ease           float64
+		interval       float64
+		retention      float64
+		wantStability  float64
+		wantDifficulty float64
 	}{
 		{2.5, 10.0, 0.9, 10.0, 6.9140563},
 		{2.5, 10.0, 0.8, 3.01572, 9.393428},
@@ -423,7 +421,11 @@ func TestMemoryStateFromSM2InvalidInput(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			_, err := f.MemoryStateFromSM2(tc.ease, tc.interval, tc.retention)
 			if err == nil {
-				t.Error("expected error, got nil")
+				t.Fatal("expected error, got nil")
+			}
+			var fsrsErr *Error
+			if !errors.As(err, &fsrsErr) || fsrsErr.Code != ErrCodeInvalidInput {
+				t.Errorf("expected ErrCodeInvalidInput, got=%v", err)
 			}
 		})
 	}

--- a/reschedule_test.go
+++ b/reschedule_test.go
@@ -509,7 +509,7 @@ func TestReschedule(t *testing.T) {
 		var currentCard Card
 		var historyCards []Card
 		for _, review := range reviews {
-				item, err := f.Next(currentCard, review.Review, review.Rating)
+			item, err := f.Next(currentCard, review.Review, review.Rating)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -517,7 +517,10 @@ func TestReschedule(t *testing.T) {
 			historyCards = append(historyCards, currentCard)
 		}
 
-		forgetItem := f.Forget(currentCard, time.Date(2024, 10, 27, 0, 0, 0, 0, time.UTC), false)
+		forgetItem, err := f.Forget(currentCard, time.Date(2024, 10, 27, 0, 0, 0, 0, time.UTC), false)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 		currentCard = forgetItem.Card
 
 		result, err := f.Reschedule(currentCard, reviews, RescheduleOptions{

--- a/weights.go
+++ b/weights.go
@@ -1,6 +1,9 @@
 package fsrs
 
-import "math"
+import (
+	"fmt"
+	"math"
+)
 
 type Weights [21]float64
 
@@ -33,20 +36,25 @@ func DefaultWeights() Weights {
 // ConvertV5Weights converts v5 [19]float64 weights to v6 [21]float64 weights.
 // W[19] is set to 0.0 (no short-term stability decay in v5) and
 // W[20] is set to 0.5 (v5 used a fixed decay of -0.5).
-func ConvertV5Weights(v5 [19]float64) Weights {
+// Returns an error if any input parameter is non-finite (NaN or Inf).
+func ConvertV5Weights(v5 [19]float64) (Weights, error) {
+	if err := validateFiniteWeights(v5[:]); err != nil {
+		return Weights{}, err
+	}
+
 	var w Weights
 	copy(w[:19], v5[:])
 	w[19] = 0.0
 	w[20] = fsrs5DefaultDecay
-	return w
+	return w, nil
 }
 
 const fsrs5DefaultDecay = 0.5
 
 func validateFiniteWeights(weights []float64) error {
-	for _, val := range weights {
+	for i, val := range weights {
 		if math.IsNaN(val) || math.IsInf(val, 0) {
-			return ErrInvalidWeightsValue
+			return &Error{Code: ErrCodeInvalidWeightsValue, Message: fmt.Sprintf("fsrs: invalid weight W[%d]: must be finite", i)}
 		}
 	}
 	return nil
@@ -90,13 +98,9 @@ func MigrateWeights(weights []float64) (Weights, error) {
 		copy(v45[:], weights)
 		return ConvertV45Weights(v45)
 	case 19:
-		if err := validateFiniteWeights(weights); err != nil {
-			return Weights{}, err
-		}
 		var v5 [19]float64
 		copy(v5[:], weights)
-		w := ConvertV5Weights(v5)
-		return w, nil
+		return ConvertV5Weights(v5)
 	case 21:
 		if err := validateFiniteWeights(weights); err != nil {
 			return Weights{}, err

--- a/weights_test.go
+++ b/weights_test.go
@@ -354,7 +354,10 @@ func TestConvertV5Weights(t *testing.T) {
 	v5 := [19]float64{
 		0.4, 0.6, 2.4, 5.8, 6.81, 0.44675013, 1.36, 0.01, 1.49, 0.14, 0.94, 2.18, 0.05, 0.34, 1.26, 0.29, 2.61, 1.0, 2.0,
 	}
-	w := ConvertV5Weights(v5)
+	w, err := ConvertV5Weights(v5)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	for i := 0; i < 19; i++ {
 		if w[i] != v5[i] {
 			t.Errorf("W[%d]: expected %v, got %v", i, v5[i], w[i])
@@ -366,4 +369,40 @@ func TestConvertV5Weights(t *testing.T) {
 	if w[20] != 0.5 {
 		t.Errorf("W[20]: expected 0.5, got %v", w[20])
 	}
+}
+
+func TestConvertV5WeightsInvalidInput(t *testing.T) {
+	t.Run("NaN input", func(t *testing.T) {
+		v5 := [19]float64{
+			0.4, 0.6, 2.4, 5.8, 6.81, 0.44675013, 1.36, 0.01, 1.49, 0.14, 0.94, 2.18, 0.05, 0.34, 1.26, 0.29, 2.61, 1.0, math.NaN(),
+		}
+		_, err := ConvertV5Weights(v5)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		var fsrsErr *Error
+		if !errors.As(err, &fsrsErr) || fsrsErr.Code != ErrCodeInvalidWeightsValue {
+			t.Errorf("expected ErrCodeInvalidWeightsValue, got=%v", err)
+		}
+		if !errors.Is(err, ErrInvalidWeightsValue) {
+			t.Errorf("expected errors.Is(err, ErrInvalidWeightsValue), got=%v", err)
+		}
+	})
+
+	t.Run("Inf input", func(t *testing.T) {
+		v5 := [19]float64{
+			0.4, 0.6, 2.4, 5.8, 6.81, 0.44675013, 1.36, 0.01, 1.49, 0.14, 0.94, 2.18, 0.05, 0.34, 1.26, 0.29, 2.61, math.Inf(1), 2.0,
+		}
+		_, err := ConvertV5Weights(v5)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		var fsrsErr *Error
+		if !errors.As(err, &fsrsErr) || fsrsErr.Code != ErrCodeInvalidWeightsValue {
+			t.Errorf("expected ErrCodeInvalidWeightsValue, got=%v", err)
+		}
+		if !errors.Is(err, ErrInvalidWeightsValue) {
+			t.Errorf("expected errors.Is(err, ErrInvalidWeightsValue), got=%v", err)
+		}
+	})
 }


### PR DESCRIPTION
## Summary

Standardizes the public API so all scheduler operations surface invalid-input conditions via the package's structured `Error` type. `Forget` now returns `(SchedulingInfo, error)` and validates input via `validateCard`; `ConvertV5Weights` returns `(Weights, error)` and validates non-finite input. All scheduler operations remain methods on `*FSRS`, including the internal `handleManualRating` / `calculateManualRecord` helpers used by `Reschedule`.

## Changes

- Keep `Forget` and `Rollback` as methods on `*FSRS`. `Forget` now validates input via `validateCard` and returns `(SchedulingInfo, error)`.
- Make `ConvertV5Weights` return `(Weights, error)` and validate non-finite input via `validateFiniteWeights`, which now reports the offending index in the error. `MigrateWeights` delegates validation to `ConvertV5Weights`.
- Keep `handleManualRating` / `calculateManualRecord` (reschedule.go) as methods on `*FSRS` for consistency with the rest of the scheduler.
- Replace `fmt.Errorf` returns in `memory.go` with `&Error{Code: ErrCodeInvalidInput}`.
- Expand tests to assert error codes via `errors.As` and add validation subtests for `Forget` and `ConvertV5Weights`.

## Breaking Changes

Scheduled for v4.0.0 (not yet released).

- **`Forget`**: signature changed from `SchedulingInfo` to `(SchedulingInfo, error)`. Callers must handle the new error return. Receiver usage (`f.Forget(...)`) is unchanged.
- **`ConvertV5Weights`**: `Weights` → `(Weights, error)`. Callers must handle the new error return.

`Rollback` is **not** a breaking change — it was already a method returning `(Card, error)` and remains one.

All breaks are compile-time detectable with mechanical migrations.

Closes #77.

---

<!-- start-auto-generated -->
This is an auto-generated description by sintesitech[bot]

Standardizes the public API's input validation and error handling across all FSRS scheduler operations, replacing generic `fmt.Errorf` panics and silent failures with structured `Error` types. `Forget` and `ConvertV5Weights` now return explicit `error` values, validated through `validateCard` and `validateFiniteWeights` respectively, while internal helpers remain methods on `*FSRS` for consistency. These are compile-time detectable breaking changes scheduled for v4.0.0 with mechanical migrations.

---
<sup>Written for commit d746559c8f5c7b68816d2ca76b0aa9542029b64c. Summary will update on new commits.</sup>
<!-- end-auto-generated -->