### PR TITLE
refactor(api): remove deprecated GetRetrievability and fix misleading godoc

### DIFF
--- a/alea.go
+++ b/alea.go
@@ -76,6 +76,8 @@ func mash() func(string) float64 {
 	}
 }
 
+// PRNG is a pseudo-random number generator function that returns a float64
+// in [0, 1).
 type PRNG func() float64
 
 // Alea returns a deterministic PRNG seeded with the given value.
@@ -89,6 +91,8 @@ func Alea(seed any) PRNG {
 	return prng
 }
 
+// Double returns a double-precision random float64 in [0, 1) with 53 bits
+// of entropy.
 func (prng PRNG) Double() float64 {
 	return prng() + float64(uint32(prng()*0x200000))*1.1102230246251565e-16 // 2^-53
 }

--- a/arithmetic_test.go
+++ b/arithmetic_test.go
@@ -73,7 +73,6 @@ func TestStabilityToInterval(t *testing.T) {
 	})
 }
 
-
 func TestNextInterval(t *testing.T) {
 	p := DefaultParam()
 	fsrs := NewFSRS(p)

--- a/errors.go
+++ b/errors.go
@@ -83,31 +83,31 @@ var (
 		Message: "fsrs: invalid weights slice length: must be 17, 19, or 21",
 	}
 
-	// ErrInvalidWeightsValue is returned when any weight parameter is NaN or Inf.
+	// ErrInvalidWeightsValue matches errors returned when any weight parameter is NaN or Inf.
 	ErrInvalidWeightsValue = &Error{
 		Code:    ErrCodeInvalidWeightsValue,
 		Message: "fsrs: invalid weights value: must be finite",
 	}
 
-	// ErrInvalidDecay is returned by Validate when W[20] (decay) is not positive.
+	// ErrInvalidDecay matches errors returned by Validate when W[20] (decay) is not positive.
 	ErrInvalidDecay = &Error{
 		Code:    ErrCodeInvalidDecay,
 		Message: "fsrs: invalid weight W[20]: must be > 0",
 	}
 
-	// ErrInvalidRetention is returned by Validate when RequestRetention is outside (0, 1].
+	// ErrInvalidRetention matches errors returned by Validate when RequestRetention is outside (0, 1].
 	ErrInvalidRetention = &Error{
 		Code:    ErrCodeInvalidRetention,
 		Message: "fsrs: invalid RequestRetention: must be in (0, 1]",
 	}
 
-	// ErrInvalidMaxInterval is returned by Validate when MaximumInterval is outside (0, 36500].
+	// ErrInvalidMaxInterval matches errors returned by Validate when MaximumInterval is outside (0, 36500].
 	ErrInvalidMaxInterval = &Error{
 		Code:    ErrCodeInvalidMaxInterval,
 		Message: "fsrs: invalid MaximumInterval: must be in (0, 36500]",
 	}
 
-	// ErrInvalidSteps is returned by Validate when a learning or relearning step is invalid.
+	// ErrInvalidSteps matches errors returned by Validate when a learning or relearning step is invalid.
 	ErrInvalidSteps = &Error{
 		Code:    ErrCodeInvalidSteps,
 		Message: "fsrs: invalid steps: must be finite and >= 0",

--- a/fsrs.go
+++ b/fsrs.go
@@ -77,8 +77,3 @@ func (f *FSRS) Retrievability(card Card, now time.Time) (float64, error) {
 	elapsedDays := math.Max(0, dateDiffRaw(card.LastReview, now))
 	return f.Parameters.ForgettingCurve(elapsedDays, card.Stability), nil
 }
-
-// Deprecated: Use Retrievability instead. Will be removed in v4.0.0
-func (f *FSRS) GetRetrievability(card Card, now time.Time) (float64, error) {
-	return f.Retrievability(card, now)
-}

--- a/fuzz.go
+++ b/fuzz.go
@@ -25,6 +25,9 @@ func FuzzRanges() []fuzzRange {
 	return out
 }
 
+// ApplyFuzz applies interval randomization to avoid all cards being due on
+// the same day. Returns the interval unchanged when enableFuzz is false or
+// the interval is below the fuzz threshold (2.5 days).
 func (p *Parameters) ApplyFuzz(interval float64, elapsedDays float64, enableFuzz bool) float64 {
 	if !enableFuzz || interval < 2.5 {
 		return interval

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -119,9 +119,9 @@ func TestGetFuzzRange(t *testing.T) {
 
 	t.Run("min never exceeds max", func(t *testing.T) {
 		for _, tc := range []struct {
-		interval    float64
-		elapsed float64
-		maxInterval float64
+			interval    float64
+			elapsed     float64
+			maxInterval float64
 		}{
 			{2.5, 0, 36500},
 			{7.0, 0, 36500},

--- a/models.go
+++ b/models.go
@@ -4,6 +4,8 @@ import (
 	"time"
 )
 
+// Card represents a spaced-repetition card with its current scheduling state,
+// memory metrics (stability and difficulty), and review counters.
 type Card struct {
 	Due            time.Time `json:"Due"`
 	Stability      float64   `json:"Stability"`
@@ -29,6 +31,8 @@ func NewCard(now ...time.Time) Card {
 	return card
 }
 
+// ReviewLog captures the state of a card at the time a review was performed,
+// including the rating given, the scheduling parameters, and the review timestamp.
 type ReviewLog struct {
 	Rating         Rating    `json:"Rating"`
 	Due            time.Time `json:"Due"`
@@ -40,13 +44,19 @@ type ReviewLog struct {
 	RemainingSteps int       `json:"RemainingSteps"`
 }
 
+// SchedulingInfo pairs a scheduled Card with the ReviewLog produced by the
+// scheduling operation that created it.
 type SchedulingInfo struct {
 	Card      Card      `json:"Card"`
 	ReviewLog ReviewLog `json:"ReviewLog"`
 }
 
+// RecordLog maps each Rating to the SchedulingInfo that would result from
+// choosing that rating. It is the return type of [FSRS.Repeat].
 type RecordLog map[Rating]SchedulingInfo
 
+// Rating represents the user's response when reviewing a card.
+// Valid values are Manual (0), Again (1), Hard (2), Good (3), and Easy (4).
 type Rating int8
 
 const Manual Rating = 0
@@ -74,6 +84,8 @@ func (r Rating) String() string {
 	return "unknown"
 }
 
+// State represents the learning stage of a card in the spaced-repetition cycle.
+// Valid values are New (0), Learning (1), Review (2), and Relearning (3).
 type State int8
 
 const (
@@ -97,11 +109,15 @@ func (s State) String() string {
 	return "unknown"
 }
 
+// MemoryState holds the stability and difficulty values that characterize
+// the strength of a card's memory trace.
 type MemoryState struct {
 	Stability  float64 `json:"Stability"`
 	Difficulty float64 `json:"Difficulty"`
 }
 
+// ItemState pairs a MemoryState with the scheduled interval (in days) that
+// would result from the associated rating.
 type ItemState struct {
 	Memory   MemoryState `json:"Memory"`
 	Interval float64     `json:"Interval"`
@@ -116,6 +132,7 @@ type ReviewEntry struct {
 // ReviewEntries is a chronologically ordered sequence of ReviewEntry values.
 type ReviewEntries []ReviewEntry
 
+// NextStates holds the scheduling outcome for all four ratings.
 type NextStates struct {
 	Again ItemState `json:"Again"`
 	Hard  ItemState `json:"Hard"`

--- a/parameters.go
+++ b/parameters.go
@@ -15,6 +15,8 @@ func DefaultRelearningSteps() []float64 {
 	return []float64{10}
 }
 
+// Parameters holds the FSRS scheduler configuration: retention target,
+// interval limits, weights, fuzz and short-term settings, and learning steps.
 type Parameters struct {
 	RequestRetention float64   `json:"RequestRetention"`
 	MaximumInterval  float64   `json:"MaximumInterval"`
@@ -104,10 +106,9 @@ func clipParameters(p *Parameters) {
 		w11 := clamp(p.W[11], 0.001, 5.0)
 		w13 := clamp(p.W[13], 0.001, 0.9)
 		w14 := clamp(p.W[14], 0.0, 4.0)
-		value := -(
-			math.Log(w11) +
-				math.Log(math.Pow(2.0, w13)-1.0) +
-				w14*0.3) /
+		value := -(math.Log(w11) +
+			math.Log(math.Pow(2.0, w13)-1.0) +
+			w14*0.3) /
 			float64(numRelearning)
 		w17W18Ceiling = clamp(math.Sqrt(math.Max(value, 0)), 0.01, 2.0)
 	}
@@ -141,17 +142,22 @@ func clipParameters(p *Parameters) {
 	}
 }
 
+// ForgettingCurve computes the retrievability (probability of recall) given
+// the elapsed days since the last review and the card's stability.
 func (p *Parameters) ForgettingCurve(elapsedDays float64, stability float64) float64 {
 	decay, factor := p.decayAndFactor()
 	stability = constrainStability(stability)
 	return math.Pow(1+factor*elapsedDays/stability, decay)
 }
 
+// NextState computes the resulting memory state and interval for a single rating.
 func (p *Parameters) NextState(current *MemoryState, desiredRetention float64, daysElapsed uint64, grade Rating) ItemState {
 	decay, factor := p.decayAndFactor()
 	return p.nextStateInner(current, desiredRetention, float64(daysElapsed), grade, decay, factor)
 }
 
+// NextStates computes the resulting memory state and interval for all four
+// ratings (Again, Hard, Good, Easy).
 func (p *Parameters) NextStates(current *MemoryState, desiredRetention float64, daysElapsed uint64) NextStates {
 	decay, factor := p.decayAndFactor()
 	elapsed := float64(daysElapsed)

--- a/parameters_test.go
+++ b/parameters_test.go
@@ -464,24 +464,6 @@ func TestRetrievability(t *testing.T) {
 	}
 }
 
-func TestGetRetrievabilityBackwardCompat(t *testing.T) {
-	f := NewFSRS(DefaultParam())
-	card := Card{LastReview: time.Now().Add(-24 * time.Hour), Stability: 1, State: Review}
-	now := card.LastReview.Add(24 * time.Hour)
-
-	got, err := f.GetRetrievability(card, now)
-	if err != nil {
-		t.Fatalf("deprecated GetRetrievability should still work: %v", err)
-	}
-	expected, err := f.Retrievability(card, now)
-	if err != nil {
-		t.Fatalf("Retrievability error: %v", err)
-	}
-	if got != expected {
-		t.Errorf("GetRetrievability = %v, want %v (should match Retrievability)", got, expected)
-	}
-}
-
 func BenchmarkNextStates(b *testing.B) {
 	p := DefaultParam()
 	current := &MemoryState{Stability: 51.344814, Difficulty: 7.005062}

--- a/scheduler.go
+++ b/scheduler.go
@@ -5,6 +5,8 @@ import (
 	"time"
 )
 
+// Scheduler holds the internal state for a single scheduling pass over a card.
+// It is created by [Parameters.NewBasicScheduler] or [Parameters.NewLongTermScheduler].
 type Scheduler struct {
 	parameters *Parameters
 
@@ -22,6 +24,8 @@ type implScheduler interface {
 	reviewState(Rating) SchedulingInfo
 }
 
+// Preview returns the scheduling outcome for all four ratings (Again, Hard,
+// Good, Easy) without committing to any single one.
 func (s *Scheduler) Preview() RecordLog {
 	return RecordLog{
 		Again: s.Review(Again),
@@ -31,6 +35,7 @@ func (s *Scheduler) Preview() RecordLog {
 	}
 }
 
+// Review computes the scheduling outcome for the given rating.
 func (s *Scheduler) Review(grade Rating) SchedulingInfo {
 	cardState := s.last.State
 	var item SchedulingInfo

--- a/weights.go
+++ b/weights.go
@@ -5,8 +5,10 @@ import (
 	"math"
 )
 
+// Weights holds the 21 FSRS v6 weight parameters used by the scheduler.
 type Weights [21]float64
 
+// DefaultWeights returns the default FSRS v6 weight values.
 func DefaultWeights() Weights {
 	return Weights{
 		0.212,


### PR DESCRIPTION
## Summary

Removes the deprecated `GetRetrievability` shim (breaking change) and completes godoc across the public API surface.

## Changes

- Remove `GetRetrievability` (deprecated alias of `Retrievability`) and its backward-compat test.
- Fix sentinel error comments in `errors.go`: "is returned by" → "matches errors returned when" (they are `errors.Is` comparison targets).
- Add godoc to the remaining exported types and methods across `models.go`, `parameters.go`, `alea.go`, `scheduler.go`, and `weights.go`.

## Breaking Changes

- **`GetRetrievability` removed** — callers must use `Retrievability` instead.

---

<!-- start-auto-generated -->
This is an auto-generated description by sintesitech[bot]

This refactor removes the deprecated `GetRetrievability` shim (breaking change for callers still using it), fixes misleading sentinel error comments in `errors.go`, and completes missing godoc across the public API surface in `models.go`, `parameters.go`, `alea.go`, `scheduler.go`, and `weights.go`. The result is a cleaner, fully-documented API with no remaining deprecated aliases.

---
<sup>Written for commit 926bf9d9288f893037da85cab4bbb67856399d78. Summary will update on new commits.</sup>
<!-- end-auto-generated -->